### PR TITLE
feat: add max_steps to training

### DIFF
--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -13,7 +13,9 @@ from loguru import logger
 from tqdm import tqdm
 
 from everyvoice.model.aligner.config import DFAlignerConfig
-from everyvoice.model.aligner.DeepForcedAligner.dfaligner.dataset import AlignerDataModule
+from everyvoice.model.aligner.DeepForcedAligner.dfaligner.dataset import (
+    AlignerDataModule,
+)
 from everyvoice.model.aligner.DeepForcedAligner.dfaligner.model import Aligner
 from everyvoice.model.e2e.config import EveryVoiceConfig
 from everyvoice.model.e2e.dataset import E2EDataModule
@@ -22,15 +24,21 @@ from everyvoice.model.feature_prediction.config import FastSpeech2Config
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.dataset import (
     FastSpeech2DataModule,
 )
-from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.model import FastSpeech2
+from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.model import (
+    FastSpeech2,
+)
 from everyvoice.model.vocoder.config import HiFiGANConfig
-from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.dataset import HiFiGANDataModule
+from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.dataset import (
+    HiFiGANDataModule,
+)
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.model import HiFiGAN
 
 
 def load_config_base_command(
     name: Enum,
-    model_config: Union[DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig],
+    model_config: Union[
+        DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig
+    ],
     configs,
     # Must include the above in model-specific command
     config_args: List[str],
@@ -54,7 +62,9 @@ def load_config_base_command(
 
 def preprocess_base_command(
     name: Enum,
-    model_config: Union[DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig],
+    model_config: Union[
+        DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig
+    ],
     configs,
     data,
     preprocess_categories,
@@ -95,7 +105,9 @@ def preprocess_base_command(
 
 def train_base_command(
     name: Enum,
-    model_config: Union[DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig],
+    model_config: Union[
+        DFAlignerConfig, EveryVoiceConfig, FastSpeech2Config, HiFiGANConfig
+    ],
     configs,
     data_module: Union[
         AlignerDataModule, E2EDataModule, FastSpeech2DataModule, HiFiGANDataModule
@@ -149,6 +161,7 @@ def train_base_command(
         accelerator=accelerator,
         devices=devices,
         max_epochs=config.training.max_epochs,
+        max_steps=config.training.max_steps,
         callbacks=[ckpt_callback, lr_monitor],
         strategy=strategy,
         num_nodes=nodes,

--- a/everyvoice/config/shared_types.py
+++ b/everyvoice/config/shared_types.py
@@ -116,6 +116,7 @@ class BaseTrainingConfig(ConfigModel):
     ckpt_steps: Union[int, None] = None
     ckpt_epochs: Union[int, None] = 1
     max_epochs: int = 1000
+    max_steps: int = 100000
     finetune_checkpoint: Union[FilePath, None] = None
     training_filelist: Union[Path, FilePath] = Path(
         "./path/to/your/preprocessed/training_filelist.psv"


### PR DESCRIPTION
alternative to max_epochs which is helpful when running g experiments with varying amounts of data.

Because I provide a default value, I don't need to update existing configurations, and because all models use the same base trainer, I don't need to update any specific models.