### PR TITLE
chore: Fixed filename to match the wizard's config files.

### DIFF
--- a/everyvoice/base_cli/interfaces.py
+++ b/everyvoice/base_cli/interfaces.py
@@ -26,7 +26,7 @@ def preprocess_base_command_interface(
         None, "--config-path", "-p", exists=True, dir_okay=False, file_okay=True
     ),
     output_path: Optional[Path] = typer.Option(
-        "processed_filelist.psv", "-o", "--output"
+        "filelist.psv", "-o", "--output"
     ),
     cpus: Optional[int] = typer.Option(min(4, mp.cpu_count()), "-C", "--cpus"),
     overwrite: bool = typer.Option(False, "-O", "--overwrite"),

--- a/everyvoice/preprocessor/__init__.py
+++ b/everyvoice/preprocessor/__init__.py
@@ -698,7 +698,7 @@ class Preprocessor:
 
     def preprocess(
         self,
-        output_path="processed_filelist.psv",
+        output_path="filelist.psv",
         cpus=min(5, mp.cpu_count()),
         to_process=List[str],
         overwrite=False,
@@ -723,11 +723,11 @@ class Preprocessor:
                     )
                     write_filelist(
                         filelist[:train_split],
-                        self.save_dir / f"training-{output_path.name}",
+                        self.save_dir / f"training_{output_path.name}",
                     )
                     write_filelist(
                         filelist[train_split:],
-                        self.save_dir / f"validation-{output_path.name}",
+                        self.save_dir / f"validation_{output_path.name}",
                     )
                     report = self.report()
                     with open(self.save_dir / "summary.txt", "w", encoding="utf8") as f:


### PR DESCRIPTION
A fix for bug #25 
Files are not missing, they are named incorrectly based on what the wizard outputs.