### PR TITLE
docs: put the Guides before the References in the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,5 +12,5 @@ Welcome to EveryVoice's documentation!
 
    start
    install
-   reference/index
    guides/index
+   reference/index


### PR DESCRIPTION
The Guides is probably the most important part of the documentation or at least the part that should be read first when one is getting familiar with EveryVoice. So it makes sense to display it just after Install, before the more complete but more confusing Reference section.