### PR TITLE
fix(trainer): load checkpoint without ckpt_path which doesn't allow for updated hyperparameters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 clipdetect>=0.1.3
+deepdiff>=6.5.0
 anytree>=2.8.0
 einops==0.5.0
 g2p>=1.0.20230417


### PR DESCRIPTION
fixes https://github.com/roedoejet/EveryVoice/issues/41

@davidguzmanr - can you try this PR out and see if it fixes the issue for you. It's a little annoying because it seems to lose all information about the current epoch - so the logger reverts to epoch 0, but it appears to have correctly loaded the weights and updated hyperparameters. I find it a bit surprising that PyTorch Lightning [doesn't have this figured out yet](https://github.com/Lightning-AI/lightning/issues/5339). I'm going to ~leave this as a draft~ (ok - drafts aren't possible on private repos, but please don't merge this) because I don't really want to lose the ability to statefully resume training, which this PR seems to do. But, it will let @davidguzmanr run experiments with an updated LR until we figure out a better option.