### PR TITLE
fix(vocoder): synthesize 16bit wavs instead of 32bit

### DIFF
--- a/everyvoice/model/vocoder/original_hifigan_helper/__init__.py
+++ b/everyvoice/model/vocoder/original_hifigan_helper/__init__.py
@@ -228,8 +228,8 @@ def vocoder_infer(mels, vocoder, max_wav_value, lengths=None):
     # mels (1, 80, 111) normal
     # mels small (1, 80, 5)
     with torch.no_grad():
-        wavs = vocoder(mels.transpose(1, 2)).squeeze(1)
-    wavs = wavs.cpu().numpy()
+        wavs = vocoder(mels.transpose(1, 2)).squeeze(1) * max_wav_value
+    wavs = wavs.cpu().numpy().astype("int16")
     wavs = [wav for wav in wavs]
 
     for i in range(len(mels)):


### PR DESCRIPTION
scipy [ uses the numpy dtype](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.wavfile.write.html) to determine the bitrate of wav files and we were just writing the 32bit form used in training by pytorch. This changes the output wavs to being 16bit.

