### PR TITLE
fix: handle ctrl-c in a consistent way, always aborting

### DIFF
--- a/everyvoice/wizard/__init__.py
+++ b/everyvoice/wizard/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum
 from typing import List, Optional, Union
 
@@ -99,6 +100,10 @@ class Step(_Step, NodeMixin):
         If this method returns something truthy, continue, otherwise ask the prompt again.
         """
         self.response = self.prompt()
+        if self.response is None:
+            # This is what happens when the user hits Ctrl-C
+            print("Aborted.")
+            sys.exit(1)
         if self.validate(self.response):
             self.completed = True
             try:

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -420,7 +420,7 @@ class TextProcessingStep(Step):
             0: {"fn": lambda x: x.lower(), "desc": "lowercase"},
             1: {"fn": lambda x: normalize("NFC", x), "desc": ""},
         }
-        if self.response is not None and len(self.response):
+        if self.response:
             for process in self.response:
                 process_fn = process_lookup[process]["fn"]
                 for i in tqdm(
@@ -460,7 +460,7 @@ class SoxEffectsStep(Step):
             3: ["silence", "1", "0.1", "1.0%", "-1", "0.4", "1%"],
         }
         self.state["sox_effects"] = [["channel", "1"]]
-        if self.response is not None and len(self.response):
+        if self.response:
             for effect in self.response:
                 self.state["sox_effects"].append(audio_effects[effect])
 
@@ -496,7 +496,7 @@ class SymbolSetStep(Step):
             search=True,
         )
         if punctuation is None:
-            punctuation = []
+            return None
         symbols = tuple(x for x in symbols if x not in punctuation)
         banned_symbols = get_response_from_menu_prompt(  # type: ignore
             title="Ignore utterances that contain any of the following characters:",
@@ -505,7 +505,7 @@ class SymbolSetStep(Step):
             search=True,
         )
         if banned_symbols is None:
-            banned_symbols = []
+            return None
         self.state["banned_symbols"] = banned_symbols
         symbols = tuple(x for x in symbols if x not in banned_symbols)
         ignored_symbols = get_response_from_menu_prompt(  # type: ignore
@@ -515,7 +515,7 @@ class SymbolSetStep(Step):
             search=True,
         )
         if ignored_symbols is None:
-            ignored_symbols = []
+            return None
         return Symbols(
             punctuation=punctuation,
             symbol_set=[x for x in symbols if x not in ignored_symbols],

--- a/everyvoice/wizard/prompts.py
+++ b/everyvoice/wizard/prompts.py
@@ -32,13 +32,17 @@ def get_response_from_menu_prompt(
         multi_select=multi,
         multi_select_select_on_accept=(not multi),
         multi_select_empty_ok=multi,
+        raise_error_on_interrupt=True,
         show_multi_select_hint=multi,
         show_search_hint=search,
         status_bar_style=("fg_gray", "bg_black"),
     )
     index = menu.show()
     sys.stdout.write("\033[K")
-    if index is None or return_indices:
+    if index is None:
+        # None is reserved for user abort, so return an empty list instead
+        return []  # type: ignore[return-value]
+    elif return_indices:
         return index
     else:
         if isinstance(index, tuple):


### PR DESCRIPTION
For the moment, Ctrl-C should always just abort, this commit does that. Eventually, we'll want to catch ctrl-c and make it save a partial state, but that's for future work.

Fixes #85