### PR TITLE
Revert "ci: suppress redundant tests runs on PR and push"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 name: Run Tests
 on:
-  pull_request:
-    types: [review_requested]
-  push:
+  - push
+  - pull_request
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
It turns out doing CI on review_requested is not great, because:
 - if you request 2 or 3 reviews, it triggers the action 2 or 3 times
 - when the branch needs a real merge, we do want the result of the merge tested in CI, so we lost important validation

So I vote we go back to running tests on PR, not just on review_requested. If we find a way to skip the run when the merge base is the same as base-ref, i.e., a fast-forward merge is possible, then we should implement that, but this week I've missed having my PRs exercised in CI when the base was some commits behind because some other PR got merged.

This reverts commit 91f4a35307abfef8906c59367793681ea4712938.