### PR TITLE
ci: abort deploy docs when a new commit is pushed to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
  docs:
     # Create latest docs


### PR DESCRIPTION
docs.yaml pushes to branch gh-pages. When two or more PRs are merged in quick succession, we only want the docs from the last one to get deployed.

Use the concurrency mechanism to cancel the earlier run in progress.