### PR TITLE
ci: optimize the installation steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install -y libsndfile1
       - name: Install dependencies and package
         run: |
-          CUDA_TAG=cu118 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
           pip install cython
           pip install -e .
       - name: Install documentation dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,12 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.9
-      - name: Install sox
+      - name: Install sox and use conda to optimize other installs
         run: |
-          conda install -y sox -c conda-forge
+          conda install -y sox $(grep "pycountry\|pyworld" requirements.txt) -c conda-forge
       - name: Install dependencies and package
         run: |
-          CUDA_TAG=cu118 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
           pip install -r requirements.test.txt
           pip install cython
           pip install -e .


### PR DESCRIPTION
After much mucking about with timing and caching, it turns out the most effective CI optimization is to install CPU-only torch, which is much smaller than the CUDA variant, and is all we need since we have no GPUs in the CI runner.

Also, conda-forge has precompiled pycountry and pyworld which are faster to install. They're not "better", but they're useful here to speed up the CI install process.