### PR TITLE
fix: Deprecated feature in v2.X

### DIFF
--- a/everyvoice/config/preprocessing_config.py
+++ b/everyvoice/config/preprocessing_config.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Annotated, Any, List, Optional, Union
 
+from annotated_types import Ge, Le
 from loguru import logger
 from pydantic import Field, FilePath, ValidationInfo, field_validator, model_validator
 
@@ -76,7 +77,7 @@ class PreprocessingConfig(PartialLoadConfig):
     pitch_phone_averaging: bool = True
     energy_phone_averaging: bool = True
     value_separator: str = "--"
-    train_split: float = Field(0.9, min=0.0, max=1.0)
+    train_split: Annotated[float, Ge(0.0), Le(1.0)] = 0.9
     dataset_split_seed: int = 1234
     save_dir: PossiblyRelativePath = Path("./preprocessed/YourDataSet")
     audio: AudioConfig = Field(default_factory=AudioConfig)


### PR DESCRIPTION
This fixes the following deprecation warning
```sh
/home/sam037/.conda/envs/EveryVoice.sl/lib/python3.9/site-packages/pydantic/fields.py:799: PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'min', 'max'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration
Guide at https://errors.pydantic.dev/2.5/migration/
```

# Documentation

[Annotated with Ge, Le](https://github.com/annotated-types/annotated-types#gt-ge-lt-le)
Express inclusive and/or exclusive bounds on orderable values - which may be numbers, dates, times, strings, sets, etc. Note that the boundary value need not be of the same type that was annotated, so long as they can be compared: Annotated[int, Gt(1.5)] is fine, for example, and implies that the value is an integer x such that x > 1.5.

We suggest that implementors may also interpret functools.partial(operator.le, 1.5) as being equivalent to Gt(1.5), for users who wish to avoid a runtime dependency on the annotated-types package.

To be explicit, these types have the following meanings:

Gt(x) - value must be "Greater Than" x - equivalent to exclusive minimum
Ge(x) - value must be "Greater than or Equal" to x - equivalent to inclusive minimum
Lt(x) - value must be "Less Than" x - equivalent to exclusive maximum
Le(x) - value must be "Less than or Equal" to x - equivalent to inclusive maximum

[Custom Types](https://docs.pydantic.dev/2.5/concepts/types/#custom-types)
```python
from annotated_types import Gt
from typing_extensions import Annotated

from pydantic import TypeAdapter, ValidationError

PositiveInt = Annotated[int, Gt(0)]

ta = TypeAdapter(PositiveInt)

print(ta.validate_python(1))
#> 1

try:
    ta.validate_python(-1)
except ValidationError as exc:
    print(exc)
    """
    1 validation error for constrained-int
      Input should be greater than 0 [type=greater_than, input_value=-1, input_type=int]
    """
```