### PR TITLE
perf: There is no need to load all of pandas just to build a simple lookup table.

### DIFF
--- a/everyvoice/tests/test_text.py
+++ b/everyvoice/tests/test_text.py
@@ -6,6 +6,7 @@ from unittest import TestCase, main
 from everyvoice.config.text_config import Symbols, TextConfig
 from everyvoice.model.feature_prediction.config import FeaturePredictionConfig
 from everyvoice.text import TextProcessor
+from everyvoice.text.lookups import build_lookup
 
 
 class TextTest(TestCase):
@@ -162,6 +163,31 @@ class TextTest(TestCase):
         )
         self.assertIn("3", self.base_text_processor.missing_symbols)
         self.assertEqual(self.base_text_processor.missing_symbols["3"], 1)
+
+
+class LookupTableTest(TestCase):
+    def test_build_lookup(self):
+        """Make sure the original order of the keys is preserved"""
+        key = "speaker"
+        data = [
+            {key: "Samuel"},
+            {key: "Eric"},
+            {key: "Eric"},
+            {key: "Marc"},
+            {key: "Aidan"},
+            {key: "Marc"},
+            {key: "Samuel"},
+        ]
+        speaker2id = build_lookup(data, key)
+        self.assertDictEqual(
+            speaker2id,
+            {
+                "Samuel": 0,
+                "Eric": 1,
+                "Marc": 2,
+                "Aidan": 3,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/everyvoice/text/lookups.py
+++ b/everyvoice/text/lookups.py
@@ -8,8 +8,9 @@ def build_lookup(items: Sequence[Dict[str, str]], key: str) -> Dict[str, int]:
     """
     Create a lookup table from a list of entries and a key into those entries.
     """
-    uniq_items = set((item[key] for item in items))
-    return {item: i for i, item in enumerate(sorted(uniq_items))}
+    # Using a dictionary instead of a set to preserve the order.
+    uniq_items = {item[key]: 1 for item in items}
+    return {item: i for i, item in enumerate(uniq_items.keys())}
 
 
 class LookupTables:


### PR DESCRIPTION
Load pandas implies loading 522 files.  A simple set can to the job of finding unique values.