### PR TITLE
Allow validation every N epochs Fixes #205

### DIFF
--- a/everyvoice/.schema/everyvoice-aligner-schema-0.1.json
+++ b/everyvoice/.schema/everyvoice-aligner-schema-0.1.json
@@ -262,6 +262,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -275,6 +276,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -284,6 +286,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -478,8 +486,8 @@
         "train_split": {
           "default": 0.9,
           "description": "The amount of the dataset to use for training. The rest will be used as validation. Hold some of the validation set out for a test set if you are performing experiments.",
-          "max": 1.0,
-          "min": 0.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
           "title": "Train Split",
           "type": "number"
         },

--- a/everyvoice/.schema/everyvoice-shared-data-schema-0.1.json
+++ b/everyvoice/.schema/everyvoice-shared-data-schema-0.1.json
@@ -173,8 +173,8 @@
     "train_split": {
       "default": 0.9,
       "description": "The amount of the dataset to use for training. The rest will be used as validation. Hold some of the validation set out for a test set if you are performing experiments.",
-      "max": 1.0,
-      "min": 0.0,
+      "maximum": 1.0,
+      "minimum": 0.0,
       "title": "Train Split",
       "type": "number"
     },

--- a/everyvoice/.schema/everyvoice-spec-to-wav-schema-0.1.json
+++ b/everyvoice/.schema/everyvoice-spec-to-wav-schema-0.1.json
@@ -415,6 +415,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -428,6 +429,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -437,6 +439,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -601,8 +609,8 @@
         "train_split": {
           "default": 0.9,
           "description": "The amount of the dataset to use for training. The rest will be used as validation. Hold some of the validation set out for a test set if you are performing experiments.",
-          "max": 1.0,
-          "min": 0.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
           "title": "Train Split",
           "type": "number"
         },

--- a/everyvoice/.schema/everyvoice-text-to-spec-schema-0.1.json
+++ b/everyvoice/.schema/everyvoice-text-to-spec-schema-0.1.json
@@ -306,6 +306,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -319,6 +320,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -328,6 +330,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -420,6 +428,55 @@
           ],
           "default": null,
           "title": "Vocoder Path"
+        },
+        "mel_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the spec loss by this weight",
+          "title": "Mel Loss Weight",
+          "type": "number"
+        },
+        "postnet_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the postnet loss by this weight",
+          "title": "Postnet Loss Weight",
+          "type": "number"
+        },
+        "pitch_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the pitch loss by this weight",
+          "title": "Pitch Loss Weight",
+          "type": "number"
+        },
+        "energy_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the energy loss by this weight",
+          "title": "Energy Loss Weight",
+          "type": "number"
+        },
+        "duration_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the duration loss by this weight",
+          "title": "Duration Loss Weight",
+          "type": "number"
+        },
+        "attn_ctc_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the Attention CTC loss by this weight",
+          "title": "Attn Ctc Loss Weight",
+          "type": "number"
+        },
+        "attn_bin_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the Attention Binarization loss by this weight",
+          "title": "Attn Bin Loss Weight",
+          "type": "number"
+        },
+        "attn_bin_loss_warmup_epochs": {
+          "default": 100,
+          "description": "Scale the Attention Binarization loss by (current_epoch / attn_bin_loss_warmup_epochs) until the number of epochs defined by attn_bin_loss_warmup_epochs is reached.",
+          "minimum": 1,
+          "title": "Attn Bin Loss Warmup Epochs",
+          "type": "integer"
         }
       },
       "title": "FastSpeech2TrainingConfig",
@@ -527,8 +584,8 @@
         "train_split": {
           "default": 0.9,
           "description": "The amount of the dataset to use for training. The rest will be used as validation. Hold some of the validation set out for a test set if you are performing experiments.",
-          "max": 1.0,
-          "min": 0.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
           "title": "Train Split",
           "type": "number"
         },

--- a/everyvoice/.schema/everyvoice-text-to-wav-schema-0.1.json
+++ b/everyvoice/.schema/everyvoice-text-to-wav-schema-0.1.json
@@ -396,6 +396,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -409,6 +410,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -418,6 +420,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -585,6 +593,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -598,6 +607,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -607,6 +617,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -901,6 +917,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -914,6 +931,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -923,6 +941,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -1015,6 +1039,55 @@
           ],
           "default": null,
           "title": "Vocoder Path"
+        },
+        "mel_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the spec loss by this weight",
+          "title": "Mel Loss Weight",
+          "type": "number"
+        },
+        "postnet_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the postnet loss by this weight",
+          "title": "Postnet Loss Weight",
+          "type": "number"
+        },
+        "pitch_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the pitch loss by this weight",
+          "title": "Pitch Loss Weight",
+          "type": "number"
+        },
+        "energy_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the energy loss by this weight",
+          "title": "Energy Loss Weight",
+          "type": "number"
+        },
+        "duration_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the duration loss by this weight",
+          "title": "Duration Loss Weight",
+          "type": "number"
+        },
+        "attn_ctc_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the Attention CTC loss by this weight",
+          "title": "Attn Ctc Loss Weight",
+          "type": "number"
+        },
+        "attn_bin_loss_weight": {
+          "default": 1.0,
+          "description": "Multiply the Attention Binarization loss by this weight",
+          "title": "Attn Bin Loss Weight",
+          "type": "number"
+        },
+        "attn_bin_loss_warmup_epochs": {
+          "default": 100,
+          "description": "Scale the Attention Binarization loss by (current_epoch / attn_bin_loss_warmup_epochs) until the number of epochs defined by attn_bin_loss_warmup_epochs is reached.",
+          "minimum": 1,
+          "title": "Attn Bin Loss Warmup Epochs",
+          "type": "integer"
         }
       },
       "title": "FastSpeech2TrainingConfig",
@@ -1249,6 +1322,7 @@
         "ckpt_steps": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -1262,6 +1336,7 @@
         "ckpt_epochs": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -1271,6 +1346,12 @@
           "default": 1,
           "description": "The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
           "title": "Ckpt Epochs"
+        },
+        "check_val_every_n_epoch": {
+          "default": 1,
+          "description": "Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+          "title": "Check Val Every N Epoch",
+          "type": "integer"
         },
         "max_epochs": {
           "default": 1000,
@@ -1491,8 +1572,8 @@
         "train_split": {
           "default": 0.9,
           "description": "The amount of the dataset to use for training. The rest will be used as validation. Hold some of the validation set out for a test set if you are performing experiments.",
-          "max": 1.0,
-          "min": 0.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
           "title": "Train Split",
           "type": "number"
         },

--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -177,6 +177,7 @@ def train_base_command(
         devices=devices,
         max_epochs=config.training.max_epochs,
         max_steps=config.training.max_steps,
+        check_val_every_n_epoch=config.training.check_val_every_n_epoch,
         callbacks=[ckpt_callback, lr_monitor],
         strategy=strategy,
         num_nodes=nodes,

--- a/everyvoice/config/shared_types.py
+++ b/everyvoice/config/shared_types.py
@@ -155,6 +155,10 @@ class BaseTrainingConfig(PartialLoadConfig):
         1,
         description="The interval (in epochs) for saving a checkpoint. You can also save checkpoints after n steps by using 'ckpt_steps'",
     )
+    check_val_every_n_epoch: int = Field(
+        1,
+        description="Run validation after every n epochs. Defaults to 1, but if you have a small dataset you should change this to be larger to speed up training",
+    )
     max_epochs: int = Field(1000, description="Stop training after this many epochs")
     max_steps: int = Field(100000, description="Stop training after this many steps")
     finetune_checkpoint: Union[PossiblyRelativePath, None] = Field(


### PR DESCRIPTION
Fixes https://github.com/roedoejet/EveryVoice/issues/205 which allows us to run the validation step after every N epochs. This is useful for small datasets where validation runs too often when N=1.