### PR TITLE
ci: fail CI if everyvoice -h imports shared_types, that is slow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,10 @@ jobs:
             echo "Please run 'PYTHONPROFILEIMPORTTIME=1 everyvoice -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."; \
             false; \
           fi
+          if grep -q shared_types importtime.txt; then \
+            echo "ERROR: please be careful not to cause shared_types to be imported when the CLI just loads. It is an expensive import."; \
+            false; \
+          fi
       - name: Report help speed in PR
         if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@v2


### PR DESCRIPTION
Let's just be a bit more agressive blocking expensive imports: the easiest way to let expensive imports slip into `everyvoice -h` is by accidentally causing it to import `everyvoice.config.shared_types`, directly or indirectly. So let's explicitly look for the and reject a commit in CI if it causes this.