### PR TITLE
fix: our test*.py are not executable, let's not pretend they are

### DIFF
--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import os
 import tempfile

--- a/everyvoice/tests/test_configs.py
+++ b/everyvoice/tests/test_configs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import tempfile
 import time

--- a/everyvoice/tests/test_dataloader.py
+++ b/everyvoice/tests/test_dataloader.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from tqdm import tqdm
 
 from everyvoice.config.type_definitions import TargetTrainingTextRepresentationLevel

--- a/everyvoice/tests/test_model.py
+++ b/everyvoice/tests/test_model.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import json
 import tempfile
 from pathlib import Path

--- a/everyvoice/tests/test_preprocessing.py
+++ b/everyvoice/tests/test_preprocessing.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import doctest
 import shutil
 import tempfile

--- a/everyvoice/tests/test_text.py
+++ b/everyvoice/tests/test_text.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import doctest
 import string
 from pathlib import Path

--- a/everyvoice/tests/test_utils.py
+++ b/everyvoice/tests/test_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import doctest
 import tempfile
 from pathlib import Path

--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import builtins
 import os
 import string


### PR DESCRIPTION
Without the `__main__` block at the bottom, running `./test_foo.py` just does all the importing but runs nothing.

Instead, `python -m unittest test_foo.py` works, as do various other ways to run the suite in part on in whole.