### PR TITLE
fix(ci): update pip before installing dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
           sudo apt-get install -y libsndfile1
       - name: Install dependencies and package
         run: |
+          pip install --upgrade pip
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
           pip install cython
           pip install -e .


### PR DESCRIPTION
Deploy Docs was broken due to a stale pip in the OS image or conda package

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix the mkdocs/mike deployment process, which is broken since this morning.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

High

### How to test? <!-- Explain how reviewers should test this PR. -->

I've tested it manually with commits that ran the mkdocs build without publishing with mike, see results in https://github.com/roedoejet/EveryVoice/actions/runs/8788608279

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

100%

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

 no


<!-- Add any other relevant information here -->
