### PR TITLE
ci: fix and revamp how we publish documentation with mike

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,5 @@
 name: Deploy docs
 on:
-  workflow_call:
   push:
     branches:
       - main
@@ -40,10 +39,4 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Deploy docs with mike 🚀
         run: |
-          mkdocs build
-          mike deploy --push --update-aliases latest
-      - name: Store the docs
-        uses: actions/upload-artifact@v4
-        with:
-          name: latest-docs
-          path: site/
+          mike deploy --push --update-aliases dev latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -100,31 +100,38 @@ jobs:
         tag: ${{ github.ref_name }}
         body: ${{ steps.changelog.outputs.changes }}
         token: ${{ github.token }}
-  build-docs:
-    needs:
-      - github-release
-    uses: ./.github/workflows/docs.yml
-    secrets: inherit
 
   doc-deploy:
     runs-on: ubuntu-latest
     needs:
-      - build-docs
+      - github-release
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
           fetch-depth: 0 # fetch all commits/branches
-      - name: Download the latest docs
-        uses: actions/download-artifact@v4
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          name: latest-docs
-          path: site/
+          python-version: "3.10"
+      - name: Install libsndfile
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsndfile1
+      - name: Install dependencies and package
+        run: |
+          pip install --upgrade pip
+          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+          pip install cython
+          pip install -e .
+      - name: Install documentation dependencies
+        run: |
+          pip install -r docs/requirements.txt
       - name: Setup doc deploy
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Deploy docs with mike 🚀
         run: |
-          mike deploy --push --update-aliases latest ${{ github.ref_name }} stable
+          mike deploy --push --update-aliases ${{ github.ref_name }} stable latest


### PR DESCRIPTION
Based on: https://github.com/roedoejet/g2p/pull/342

 - fix publishing the docs on release: using the artifact does not work since mike rebuilds on each call to "mike deploy"
 - adopt the same versioning model as g2p: dev is the current main, 0.1.0 and other tags for published versions, stable is an alias to the most recently published tag, latest is an alias to the most recent thing, be that a version or the current main.

Just before merging this PR, we need to manually do

```
mike delete --all
mike deploy -u dev latest
git push origin gh-pages
```

to restart the docs with this changed model. Otherwise, docs.yaml will fail with this error:
> error: alias 'latest' already specified as a version

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix the broken documentation publication part of the publish workflow.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #401

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Double check that the suggested publication model (i.e., mimicking g2p) is OK, and make sure the CI code is OK.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Should be merged before the next tag push.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Manually tested via temporary workflow in branch [dev.ej/fix-publish-docs-testing](../tree/dev.ej/fix-publish-docs-testing)
Workflow results: https://github.com/roedoejet/EveryVoice/actions/runs/8790552488
`docs` is the usual `docs.yaml`, while `doc-deploy` is copy-pasted from `publish.yaml`.
Both fail as expected on `mike deploy` with the error "error: alias 'latest' already specified as a version" and will therefore work when I do the pre-requisite manual patch to branch [gh-pages](../tree/gh-pages).

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

nope

<!-- Add any other relevant information here -->
