### PR TITLE
fix: make-everyvoice-env warns on CUDA mismatch but continue

### DIFF
--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -112,11 +112,9 @@ else
         if nvidia-smi | grep -q "CUDA Version: $CUDA_VERSION "; then
             : # CUDA version OK
         else
-            echo "Mismatched CUDA version. Please specify --cuda CUDA_VERSION to what is installed on your system."
-            echo -n "Found: "
+            echo "Warning: Mismatched CUDA version found. Specified: CUDA_VERSION=$CUDA_VERSION. Found:"
             nvidia-smi | grep CUDA
-            echo "Specified: CUDA_VERSION=$CUDA_VERSION"
-            exit 1
+            echo "Please make sure the CUDA version available at runtime will match $CUDA_VERSION."
         fi
     else
         echo "Please make sure the CUDA version installed on your system matches CUDA_VERSION=$CUDA_VERSION."


### PR DESCRIPTION


<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Allow make-everyvoice-env to continue even if there is a CUDA version mismatch, because sometimes the install and production environments might differ.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #365

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a: we don't have CI for make-everyvoice-env. Maybe we should?

### How to test? <!-- Explain how reviewers should test this PR. -->

run `./make-everyvoice-env -n foo --cuda 11.9` and see it warn but proceed (and then fail to install because that's a bogus version)

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
