### PR TITLE
fix: lock protobuf to a version compatible with tensorboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ merge-args
 nltk==3.7
 pandas~=2.0
 panphon==0.20.0
+protobuf~=4.25  # https://github.com/roedoejet/EveryVoice/issues/387
 pycountry==22.3.5
 pydantic[email]>=2.4.2
 pympi-ling


### PR DESCRIPTION
Trivial to test, just `pip install -e .` and you should see `protobuf==4.25.3` installed (if you have previously not installed protobuf, or if you had previously installed 5.26.x) and tensoboard work as expected.

Fixes #387
