### PR TITLE
fix: multiple small improvements to the wizard

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -284,6 +284,13 @@ class WizardTest(TestCase):
                 self.assertFalse(step.validate(tmpdirname))
             os.unlink(dataset_file)
 
+            # Bad case 3: file under read-only directory
+            ro_dir = Path(tmpdirname) / "read-only"
+            ro_dir.mkdir(mode=0x555)
+            with capture_stdout() as out:
+                self.assertFalse(step.validate(str(ro_dir)))
+            self.assertIn("could not create", out.getvalue())
+
             # Good case
             with capture_stdout() as stdout:
                 with monkeypatch(step, "prompt", Say(tmpdirname)):
@@ -295,11 +302,16 @@ class WizardTest(TestCase):
 
     def test_more_data_step(self):
         """Exercise giving an invalid response and a yes response to more data."""
-        tour = Tour("testing", [basic.MoreDatasetsStep()])
-        step = tour.steps[0]
+        tour = Tour(
+            "testing",
+            [dataset.FilelistStep(state_subset="dataset_0"), basic.MoreDatasetsStep()],
+        )
+
+        step = tour.steps[1]
         self.assertFalse(step.validate("foo"))
         self.assertTrue(step.validate("yes"))
         self.assertEqual(len(step.children), 0)
+
         with patch_menu_prompt(0):  # answer 0 is "no"
             step.run()
         self.assertEqual(len(step.children), 1)
@@ -308,6 +320,15 @@ class WizardTest(TestCase):
         with patch_menu_prompt(1):  # answer 1 is "yes"
             step.run()
         self.assertGreater(len(step.descendants), 10)
+
+    def test_no_data_to_save(self):
+        """When the tour created no datasets at all, saving the config is skipped."""
+        tour = Tour("testing", [basic.MoreDatasetsStep()])
+        step = tour.steps[0]
+        with patch_menu_prompt(0), capture_stdout() as out:  # answer 0 is "no"
+            step.run()
+        self.assertEqual(len(step.children), 0)
+        self.assertIn("No dataset to save", out.getvalue())
 
     def test_dataset_name(self):
         step = dataset.DatasetNameStep()
@@ -368,10 +389,6 @@ class WizardTest(TestCase):
     def test_dataset_subtour(self):
         tour = Tour("unit testing", steps=dataset.get_dataset_steps())
 
-        wavs_dir_step = find_step(SN.wavs_dir_step, tour.steps)
-        with monkeypatch(wavs_dir_step, "prompt", Say(str(self.data_dir))):
-            wavs_dir_step.run()
-
         filelist = str(self.data_dir / "unit-test-case1.psv")
         filelist_step = find_step(SN.filelist_step, tour.steps)
         monkey = monkeypatch(filelist_step, "prompt", Say(filelist))
@@ -413,10 +430,14 @@ class WizardTest(TestCase):
             step.run()
         self.assertEqual(step.state["filelist_headers"][2], "text")
 
+        wavs_dir_step = find_step(SN.wavs_dir_step, tour.steps)
+        with monkeypatch(wavs_dir_step, "prompt", Say(str(self.data_dir))):
+            wavs_dir_step.run()
+
         validate_wavs_step = find_step(SN.validate_wavs_step, tour.steps)
-        with monkeypatch(builtins, "input", Say("no")), capture_stdout() as out:
+        with patch_menu_prompt(1), capture_stdout() as out:
             validate_wavs_step.run()
-        self.assertEqual(step.state[SN.validate_wavs_step], "no")
+        self.assertEqual(step.state[SN.validate_wavs_step][:2], "No")
         self.assertIn("Warning: 3 wav files were not found", out.getvalue())
 
         text_representation_step = find_step(
@@ -605,7 +626,9 @@ class WizardTest(TestCase):
             )
             self.assertEqual(answer, 1)
 
-    def monkey_run_tour(self, name: str, steps_and_answers: list[StepAndAnswer]):
+    def monkey_run_tour(
+        self, name: str, steps_and_answers: list[StepAndAnswer]
+    ) -> tuple[Tour, str]:
         """Create and run a tour with the monkey answers given
 
         Args:
@@ -677,10 +700,9 @@ class WizardTest(TestCase):
 
     def test_monkey_tour_2(self):
         data_dir = Path(__file__).parent / "data"
-        tour, log = self.monkey_run_tour(
+        tour, out = self.monkey_run_tour(
             "monkey tour 2",
             [
-                StepAndAnswer(dataset.WavsDirStep(), Say(str(data_dir))),
                 StepAndAnswer(
                     dataset.FilelistStep(),
                     Say(str(data_dir / "metadata.psv")),
@@ -699,9 +721,10 @@ class WizardTest(TestCase):
                     Say("no"),
                     children_answers=[RecursiveAnswers(Say("eng"))],
                 ),
+                StepAndAnswer(dataset.WavsDirStep(), Say(str(data_dir))),
                 StepAndAnswer(
                     dataset.ValidateWavsStep(),
-                    monkeypatch(builtins, "input", Say("Yes")),
+                    patch_menu_prompt(0),  # 0 is Yes
                     children_answers=[
                         RecursiveAnswers(Say(str(data_dir / "lj/wavs"))),
                         RecursiveAnswers(null_patch()),
@@ -717,8 +740,10 @@ class WizardTest(TestCase):
             ],
         )
 
-        self.assertIn("Warning: 5 wav files were not found", log)
-        self.assertIn("Great! All audio files found in directory", log)
+        tree = str(RenderTree(tour.root))
+        self.assertIn("├── Validate Wavs Step", tree)
+        self.assertIn("│   └── Validate Wavs Step", tree)
+        self.assertIn("Great! All audio files found in directory", out)
 
         # print(tour.state)
         self.assertEqual(len(tour.state["filelist_data"]), 5)

--- a/everyvoice/wizard/prompts.py
+++ b/everyvoice/wizard/prompts.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Tuple, Union
+from typing import Union
 
 import simple_term_menu
 from questionary import Style
@@ -27,18 +27,18 @@ CUSTOM_QUESTIONARY_STYLE = Style(
 
 def get_response_from_menu_prompt(
     prompt_text: str = "",
-    choices: Tuple[str, ...] = (),
+    choices: tuple[str, ...] = (),
     title: str = "",
     multi=False,
     search=False,
     return_indices=False,
-) -> Union[int, str, List[int], List[str]]:
+) -> Union[int, str, list[int], list[str]]:
     """Given some prompt text and a list of choices, create a simple terminal window
        and return the index of the choice
 
     Args:
         prompt_text (str): rich prompt text to print before menu
-        choices (List[str]): choices to display
+        choices (list[str]): choices to display
 
     Returns:
         int: index of choice


### PR DESCRIPTION

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Multiple small improvements to the wizard:

 - Move the wavs question after fully processing the filelist, including permission.
 - Catch the case where we don't have permission to write the directory with a friendly error message.
 - Make the ValidateWavsStep question use the same type of prompt as the other similar questions, for better UX consistency
 - If we accept a wavs dir / filelist combo with missing wav files, give a bright error message to make it clear future problems will happen.
 - Don't save the config if no dataset was created.

The ideas implemented here were refined in consultation with Samuel Larkin.


### Feedback sought? <!-- What should reviewers focus on in particular? -->

test the patched wizard and make sure it is pleasing

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->



### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

play with the wizard:
 - try to save files in a read-only directory and see the error message
 - give a bad wavs dir and say "no" to the validation question and see the warning
 - say no to permission and no to more data and see no config written out

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

good

