### PR TITLE
Dev.ej/466 sample wavs

### DIFF
--- a/everyvoice/tests/data/README-lj.txt
+++ b/everyvoice/tests/data/README-lj.txt
@@ -1,0 +1,2 @@
+Unit test data labelled LJ in this folder is extracted from the Public Domain
+LJ-Speech-Dataset corpus: https://keithito.com/LJ-Speech-Dataset/

--- a/everyvoice/tests/data/metadata.festival
+++ b/everyvoice/tests/data/metadata.festival
@@ -1,0 +1,5 @@
+( LJ050-0269 "The essential terms of such memoranda might well be embodied in an Executive order.")
+( LJ050-0270 "This Commission can recommend no procedures for the future protection of our Presidents which will guarantee security."  )
+( LJ050-0271 "The demands on the President in the execution of His responsibilities in today's world are so varied and complex" )
+( LJ050-0272.wav "and the traditions of the office in a democracy such as ours are so deep-seated as to preclude absolute security." )
+( LJ050-0273 "The Commission has, however, from its examination of the facts of President Kennedy's assassination" )

--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -427,16 +427,6 @@ class WizardTest(TestCase):
             step.run()
         self.assertEqual(step.state["filelist_headers"][2], "text")
 
-        wavs_dir_step = find_step(SN.wavs_dir_step, tour.steps)
-        with monkeypatch(wavs_dir_step, "prompt", Say(str(self.data_dir))):
-            wavs_dir_step.run()
-
-        validate_wavs_step = find_step(SN.validate_wavs_step, tour.steps)
-        with patch_menu_prompt(1), capture_stdout() as out:
-            validate_wavs_step.run()
-        self.assertEqual(step.state[SN.validate_wavs_step][:2], "No")
-        self.assertIn("Warning: 3 wav files were not found", out.getvalue())
-
         text_representation_step = find_step(
             SN.filelist_text_representation_step, tour.steps
         )
@@ -465,6 +455,16 @@ class WizardTest(TestCase):
             select_lang_step.state["filelist_headers"],
             ["unknown_0", "basename", "characters", "unknown_3"],
         )
+
+        wavs_dir_step = find_step(SN.wavs_dir_step, tour.steps)
+        with monkeypatch(wavs_dir_step, "prompt", Say(str(self.data_dir))):
+            wavs_dir_step.run()
+
+        validate_wavs_step = find_step(SN.validate_wavs_step, tour.steps)
+        with patch_menu_prompt(1), capture_stdout() as out:
+            validate_wavs_step.run()
+        self.assertEqual(step.state[SN.validate_wavs_step][:2], "No")
+        self.assertIn("Warning: 3 wav files were not found", out.getvalue())
 
         text_processing_step = find_step(SN.text_processing_step, tour.steps)
         # 0 is lowercase, 1 is NFC Normalization, select both

--- a/everyvoice/utils/__init__.py
+++ b/everyvoice/utils/__init__.py
@@ -259,11 +259,11 @@ def read_festival(
     """
     festival_pattern = re.compile(
         r"""
-    (\s*
-    (?P<basename>[\w\d\-\_]*)
+    \(\s*
+    (?P<basename>[\w\d\-\_.]*)
     \s*
     "(?P<text>[^"]*)"
-     )
+    \s*\)
     """,
         re.VERBOSE,
     )

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -273,12 +273,11 @@ class ValidateWavsStep(Step):
     def wav_file_early_validation(self) -> int:
         """Look for missing wav files and return the error count"""
         assert self.state is not None  # fixes mypy errors
-        basename_column = self.state["filelist_headers"].index("basename")
         wavs_dir = Path(self.state[StepNames.wavs_dir_step])
         files_not_found = []
         MAX_SAMPLES = 1000
-        filelist_data_list = self.state["filelist_data_list"]
-        file_list_size = len(filelist_data_list) - 1  # -1 to ignore header
+        filelist_data = self.state["filelist_data"]
+        file_list_size = len(filelist_data)
         sample: Sequence[int]
         if file_list_size > MAX_SAMPLES:
             print(
@@ -291,8 +290,8 @@ class ValidateWavsStep(Step):
             sampled_text = ""
             sample = range(file_list_size)
         for item in sample:
-            record = filelist_data_list[item + 1]  # +1 to skip past header
-            wav_basename = record[basename_column]
+            record = filelist_data[item]  # +1 to skip past header
+            wav_basename = record["basename"]
             wav_filename = wavs_dir / (
                 wav_basename + ("" if wav_basename.endswith(".wav") else ".wav")
             )
@@ -750,12 +749,12 @@ def get_dataset_steps(dataset_index=0):
         [
             DatasetPermissionStep(state_subset=f"dataset_{dataset_index}"),
             FilelistFormatStep(state_subset=f"dataset_{dataset_index}"),
-            WavsDirStep(state_subset=f"dataset_{dataset_index}"),
-            ValidateWavsStep(state_subset=f"dataset_{dataset_index}"),
             FilelistTextRepresentationStep(state_subset=f"dataset_{dataset_index}"),
             TextProcessingStep(state_subset=f"dataset_{dataset_index}"),
             HasSpeakerStep(state_subset=f"dataset_{dataset_index}"),
             HasLanguageStep(state_subset=f"dataset_{dataset_index}"),
+            WavsDirStep(state_subset=f"dataset_{dataset_index}"),
+            ValidateWavsStep(state_subset=f"dataset_{dataset_index}"),
             SymbolSetStep(state_subset=f"dataset_{dataset_index}"),
             SoxEffectsStep(state_subset=f"dataset_{dataset_index}"),
             DatasetNameStep(state_subset=f"dataset_{dataset_index}"),


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix two problems with the new ValidateWavsStep: it's very slow on very large corpora, and it breaks on the festival format.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #466 
Fixes #469

### Feedback sought? <!-- What should reviewers focus on in particular? -->

usual

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

alpha

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the wizard on a corpus with more than 1000 files, and see wizard check only a sample of the wav files.

Run the wizard with a festival input file, and see the wizard succeed at the validatewavs step. 
 *** but it will fail at the final step when writing the config files out, that's a different bug unrelated to this work...

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

ok


