### PR TITLE
Fixing everyvoice.tests.test_utls

### DIFF
--- a/everyvoice/tests/test_utils.py
+++ b/everyvoice/tests/test_utils.py
@@ -208,29 +208,13 @@ class DirectoryPathMustExistTest(TestCase):
     It should create a directory if it doesn't exist.
     """
 
-    def test_path_already_exists(self):
-        path = Path(__file__).parent / "data"
-        with capture_logs() as output:
-            dir = DirectoryPathMustExist(path=path)
-            # TODO: Should check that there is no log produced saying a directory was created
-            self.assertListEqual(output, [])
-        self.assertTrue(dir.path.exists())
-
-    def test_using_a_directory(self):
-        """
-        Automatically create a directory.
-        """
-        with tempfile.TemporaryDirectory() as tmpdir, capture_logs() as output:
-            path = Path(tmpdir) / "test_using_a_directory"
-            self.assertFalse(path.exists())
-            dir = DirectoryPathMustExist(path=path)
-            self.assertEqual(dir.path, path)
-            self.assertIn(
-                f"Directory at {path} does not exist. Creating...",
-                output[0],
-            )
-            self.assertTrue(path.exists())
-            self.assertTrue(dir.path.exists())
+    def test_argument_is_Path(self):
+        """directory_path_must_exist() expects a Path"""
+        with self.assertRaisesRegex(
+            ValueError,
+            r".*Assertion failed,  \[type=assertion_error, input_value='invalid_not_a_Path', input_type=str\].*",
+        ):
+            DirectoryPathMustExist(path="invalid_not_a_Path")
 
     def test_using_a_directory_with_context(self):
         """
@@ -250,6 +234,30 @@ class DirectoryPathMustExistTest(TestCase):
             # shouldn't exist because it was created relative to the context's
             # path.
             self.assertFalse(dir.path.exists())
+
+    def test_path_already_exists(self):
+        path = Path(__file__).parent / "data"
+        with capture_logs() as output:
+            dir = DirectoryPathMustExist(path=path)
+            # There should be no info logged.
+            self.assertListEqual(output, [])
+        self.assertTrue(dir.path.exists())
+
+    def test_using_a_directory(self):
+        """
+        Automatically create a directory.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir, capture_logs() as output:
+            path = Path(tmpdir) / "test_using_a_directory"
+            self.assertFalse(path.exists())
+            dir = DirectoryPathMustExist(path=path)
+            self.assertEqual(dir.path, path)
+            self.assertIn(
+                f"Directory at {path} does not exist. Creating...",
+                output[0],
+            )
+            self.assertTrue(path.exists())
+            self.assertTrue(dir.path.exists())
 
 
 class GetDeviceFromAcceleratorTest(TestCase):


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Eric noticed that running the unittests would leave a directory `metadata.psv/` where ever you ran the unittests.
Note, that investigating this issue, I realized why the disabled tests marked `WIP_*` didn't work.
Those tests use a BaseModel and a context and the derived classes were missing a custom `__init__()` to propagate the context.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

fixes: #457

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Approval to merge

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Yes under `everyvoice.tests.test_utils`, but mostly reordering of test methods.

### How to test? <!-- Explain how reviewers should test this PR. -->

```sh
python -m unittest everyvoice.tests.test_utils
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
