### PR TITLE
fix: test_no_permissions() should leave a logs_and_checkpoints/

### DIFF
--- a/everyvoice/tests/test_preprocessing.py
+++ b/everyvoice/tests/test_preprocessing.py
@@ -64,11 +64,10 @@ class PreprocessingTest(PreprocessedAudioFixture, BasicTestCase):
         no_permissions_args["preprocessing"]["source_data"][0][
             "permissions_obtained"
         ] = False
-        # TODO: remove this when https://github.com/roedoejet/EveryVoice/issues/483 is fixed
         with tempfile.TemporaryDirectory() as tmpdir:
-            no_permissions_args["training"]["logger"]["save_dir"] = tmpdir
-            with self.assertRaises(ValueError):
-                FeaturePredictionConfig(**no_permissions_args)
+            with init_context({"writing_config": Path(tmpdir)}):
+                with self.assertRaises(ValueError):
+                    FeaturePredictionConfig(**no_permissions_args)
 
     def test_process_audio_for_alignment(self):
         config = AlignerConfig(contact=self.contact)


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make sure `test_no_permissions()` doesn't leave a `logs_and_checkpoints/` behind.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

fixes: #483 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Approval to merge.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None.

### How to test? <!-- Explain how reviewers should test this PR. -->

```sh
python -m unittest everyvoice.tests.test_preprocessing.PreprocessingTest.test_no_permissions
find -name logs_and_checkpoints
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Good.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No.

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

None.

<!-- Add any other relevant information here -->
