### PR TITLE
fix(wizard): fixes non-updating keyword of text in data dictionary

### DIFF
--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -372,6 +372,13 @@ class FilelistTextRepresentationStep(Step):
         for i, header in enumerate(self.state["filelist_headers"]):
             if header == "text":
                 self.state["filelist_headers"][i] = self.response
+        # Rename the "text" key according to the new alias:
+        if "filelist_data" in self.state:
+            for item in self.state["filelist_data"]:
+                filelist_format = self.state[
+                    StepNames.filelist_text_representation_step
+                ]
+                item[filelist_format] = item.pop("text")
 
 
 # HEADER SELECTION


### PR DESCRIPTION
Although the bug majorly affected festival data only, updating 'text' keyword is done in general way now. So, if sv-like data is read into dict, it should work well. Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/496

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->
Makes the wizard work for festival data format.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/496


### Feedback sought? <!-- What should reviewers focus on in particular? -->
Check if it works.


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
Medium. Blocks testing of the developed solution for the issue https://github.com/EveryVoiceTTS/EveryVoice/issues/470.


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
Added a new complete-tour wizard test for data in the festival format.


### How to test? <!-- Explain how reviewers should test this PR. -->
Try to create a new project with a filelist in a festival format.


### Confidence? <!-- How confident are you that these changes are ready to merge? -->
High. Quite a minor fix.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->
Probably, yes. Depends on how important the ability of work with data in the festival format is.


### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->
No


<!-- Add any other relevant information here -->
