### PR TITLE
fix(deps): lock pydantic <2.8 until we fix bug #498

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas~=2.0
 panphon==0.20.0
 protobuf~=4.25  # https://github.com/EveryVoiceTTS/EveryVoice/issues/387
 pycountry==22.3.5
-pydantic[email]>=2.4.2
+pydantic[email]>=2.4.2,<2.8.0
 pympi-ling
 pysdtw==0.0.5
 pyworld==0.3.4


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make CI pass again while we remain incompatible with Pydantic 2.8.0

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Workaround for #498, but not a fix.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber-stamping -- CI passing is all the feedback I need.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

see #498

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
