### PR TITLE
chore: publish 0.1.0a3 with pydantic dependency fix

### DIFF
--- a/everyvoice/_version.py
+++ b/everyvoice/_version.py
@@ -2,4 +2,4 @@
 # [PEP 440 – Version Identification and Dependency Specification](https://peps.python.org/pep-0440/)
 # [Specifying Your Project’s Version](https://setuptools.pypa.io/en/latest/userguide/distribution.html)
 # [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
-VERSION = "0.1.0a2"
+VERSION = "0.1.0a3"


### PR DESCRIPTION
Preparing to publish 0.1.0a3 to pypi

TODO:
```
git push origin origin/dev.ej/v0.1.0a3:main
git tag -a -m v0.1.0a3 v0.1.0a3 origin/dev.ej/v0.1.0a3
git push origin v0.1.0a3
```