### PR TITLE
refactor: remove unreachable code and bump coverage

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -1070,11 +1070,11 @@ class WizardTest(TestCase):
                     ),
                     StepAndAnswer(
                         dataset.HasSpeakerStep(state_subset="dataset_0"),
-                        Say("no"),
+                        null_patch(),
                     ),
                     StepAndAnswer(
                         dataset.HasLanguageStep(state_subset="dataset_0"),
-                        Say("no"),
+                        null_patch(),
                         children_answers=[RecursiveAnswers(Say("und"))],
                     ),
                     StepAndAnswer(

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -617,13 +617,7 @@ def reload_filelist_data_as_dict(state):
                 state.get(StepNames.data_has_header_line_step, "yes") == "yes"
             ),
         )
-    else:
-        state["filelist_data"] = read_festival(
-            filelist_path,
-            text_field_name=state.get(
-                StepNames.filelist_text_representation_step, "text"
-            ),
-        )
+    assert isinstance(state["filelist_data"][0], dict)
 
 
 def get_iso_code(language):


### PR DESCRIPTION
reload_filelist_data_as_dict() can't have to reload a festival file, so replace the unreachable code by an assertion.

Also bump coverage by using the null_patch() and HasLanguage and HasSpeaker when testing festival, so that we run the prompt() function and let it detect that the format is festival.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Just a minor tweak

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

nudges coverage up

### Feedback sought? <!-- What should reviewers focus on in particular? -->

just review code

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

mostly just modifies tests

### How to test? <!-- Explain how reviewers should test this PR. -->

run the test suite and see coverage change

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

minor improvement on #497

<!-- Add any other relevant information here -->
