### PR TITLE
fix(tests): removes blocking of reaching children steps

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -648,14 +648,9 @@ class WizardTest(TestCase):
             """
             for step_and_answer in steps_and_answers:
                 step = step_and_answer.step
-                # print(step.name)
-                old_children_len = len(step.children)
                 with step_and_answer.monkey:
                     step.run()
-                if (
-                    len(step.children) > old_children_len
-                    and step_and_answer.children_answers
-                ):
+                if step.children and step_and_answer.children_answers:
                     # Here we assemble steps_and_answers for the recursive call from
                     # the actual children of step and the provided children_answers.
                     recursive_helper(


### PR DESCRIPTION
Children steps created at the tour initialization can be reached now. Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/508

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->
Modifies the condition for the children steps recursion in `monkey_run_tour()`, removes unreasonable blocking.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/508


### Feedback sought? <!-- What should reviewers focus on in particular? -->
Are there any cases when we don't want to run children steps of a step which has a number of children steps reduced after its run?


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
Medium. Blocks testing of the developed solution for the issue https://github.com/EveryVoiceTTS/EveryVoice/issues/470.


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
Adds no new tests.


### How to test? <!-- Explain how reviewers should test this PR. -->
Run wizard testing and check if this PR breaks anything. 


### Confidence? <!-- How confident are you that these changes are ready to merge? -->
Medium. Don't know why this condition was initially added.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->
No. Fix of a bug in tests which hasn't revealed itself so far.


### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->
No, so far.


<!-- Add any other relevant information here -->
