### PR TITLE
fix: better handling of empty filelist

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -553,6 +553,28 @@ class WizardTest(TestCase):
         self.assertEqual(len(symbol_set_step.state[SN.symbol_set_step.value]), 2)
         self.assertIn("t͡s", symbol_set_step.state[SN.symbol_set_step.value]["phones"])
 
+    def test_empty_filelist(self):
+        tour = Tour(
+            name="empty filelist",
+            steps=[
+                dataset.FilelistStep(),
+                dataset.FilelistFormatStep(),
+            ],
+        )
+        filelist = str(self.data_dir / "empty.psv")
+
+        filelist_step = tour.steps[0]
+        with monkeypatch(filelist_step, "prompt", Say(filelist)):
+            filelist_step.run()
+
+        format_step = tour.steps[1]
+        with self.assertRaises(SystemExit) as cm:
+            with patch_menu_prompt(1) as stdout:
+                format_step.run()
+            output = stdout.getvalue()
+            self.assertIn("is empty", output)
+        self.assertEqual(cm.exception.code, 1)
+
     def test_wrong_fileformat_psv(self):
         tour = Tour(
             name="mismatched fileformat",

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -2,6 +2,7 @@ import glob
 import os
 import random
 import re
+import sys
 from pathlib import Path
 from typing import Sequence
 
@@ -174,7 +175,14 @@ class FilelistFormatStep(Step):
             filelist_path, delimiter=separator, record_limit=10
         )
 
-        column_count = len(initial_records[0])
+        if len(initial_records) > 0:
+            column_count = len(initial_records[0])
+        else:
+            print(
+                f"ERROR: The filelist you specify ({filelist_path}) is empty. Please double check."
+            )
+            sys.exit(1)
+
         if column_count < 2:
             print(
                 f"File '{filelist_path}' does not look like a '{file_type}' file: no record separator found on header line."
@@ -439,11 +447,11 @@ class LanguageHeaderStep(HeaderStep):
         if self.state[StepNames.data_has_speaker_value_step] == "no":
             add_missing_speaker(self.state)
         # apply automatic conversions
-        self.state[
-            "model_target_training_text_representation"
-        ] = apply_automatic_text_conversions(
-            self.state["filelist_data"],
-            self.state[StepNames.filelist_text_representation_step],
+        self.state["model_target_training_text_representation"] = (
+            apply_automatic_text_conversions(
+                self.state["filelist_data"],
+                self.state[StepNames.filelist_text_representation_step],
+            )
         )
 
 
@@ -645,12 +653,12 @@ class SelectLanguageStep(Step):
         # Apply the language code:
         isocode = get_iso_code(self.response)
         # Apply text conversions and get target training representation
-        self.state[
-            "model_target_training_text_representation"
-        ] = apply_automatic_text_conversions(
-            self.state["filelist_data"],
-            self.state[StepNames.filelist_text_representation_step],
-            global_isocode=isocode,
+        self.state["model_target_training_text_representation"] = (
+            apply_automatic_text_conversions(
+                self.state["filelist_data"],
+                self.state[StepNames.filelist_text_representation_step],
+                global_isocode=isocode,
+            )
         )
 
 

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -178,9 +178,7 @@ class FilelistFormatStep(Step):
         if len(initial_records) > 0:
             column_count = len(initial_records[0])
         else:
-            print(
-                f"ERROR: The filelist you specify ({filelist_path}) is empty. Please double check."
-            )
+            print(f"ERROR: File ({filelist_path} is empty. Please double check.")
             sys.exit(1)
 
         if column_count < 2:


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->
Give a better prompt to the user when an empty file list is given.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
Fixes #333 


### Feedback sought? <!-- What should reviewers focus on in particular? -->
For now, if the user gives an empty list, we will give `ERROR: File ({filelist_path} is empty. Please double check.` and then let the program exit. It may be worthwhile to develop a new feature that allows the user to re-select the file. I'm open to insight on how to make this happen and we may handle it in another PR. Thanks!


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
Normal


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
Yes


### How to test? <!-- Explain how reviewers should test this PR. -->
Run `everyvoice test cli` or iniitalize `everyvoice new-project` with an empty file list.


### Confidence? <!-- How confident are you that these changes are ready to merge? -->
High


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->
No


### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->



<!-- Add any other relevant information here -->
