### PR TITLE
fix(ci): replaced trilom/file-changes-action with tj-actions/changed-files since it is not maintained

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,15 +28,12 @@ jobs:
           pip install -r requirements.dev.txt
           pip install pydantic
       - name: File changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: tj-actions/changed-files@v36
         id: file_changes
-        with:
-          prNumber: ${{ github.event.number }}
-          output: " "
       - name: pre-commit
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --files ${{ steps.file_changes.outputs.files }}
+          extra_args: --files ${{ steps.file_changes.outputs.all_changed_files }}
       - name: Pre commit lite
         uses: pre-commit-ci/lite-action@v1.0.2
         if: always()


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->
#494 adds pre-commit hooks CI but trilom/file-changes-action is unmaintained and it is suggested to replace it with tj-actions/changed-files.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->

Merge approval

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None

### How to test? <!-- Explain how reviewers should test this PR. -->

Look at github's action for `pre-commit-ci-lite` and noticed there is no longer
```
Run trilom/file-changes-action@v1.2.4
  with:
    output:  
    githubToken: ***
    fileOutput: json
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.14/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.14/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.14/x64
    Python[2](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:2)_ROOT_DIR: /opt/hostedtoolcache/Python/[3](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:3).10.14/x6[4](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:4)
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.14/x[6](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:6)4
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.14/x64/lib
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-[10](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:10)-11-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-[11](https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/10082383575/job/27876484800#step:5:11)-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Good

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

#494

<!-- Add any other relevant information here -->
