### PR TITLE
Make sure ffmpeg is installed, and show a clear message if not

### DIFF
--- a/everyvoice/demo/app.py
+++ b/everyvoice/demo/app.py
@@ -1,8 +1,11 @@
 import os
+import subprocess
+import sys
 from functools import partial
 
 import gradio as gr
 import torch
+from loguru import logger
 
 from everyvoice.config.type_definitions import TargetTrainingTextRepresentationLevel
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.synthesize import (
@@ -82,6 +85,17 @@ def synthesize_audio(
     return sr, wav[0]
 
 
+def require_ffmpeg():
+    """Make sure ffmpeg is found and can be run, or else exit"""
+    try:
+        subprocess.run(["ffmpeg", "-h"], capture_output=True)
+    except Exception:
+        logger.error(
+            "ffmpeg not found or cannot be executed.\nffmpeg is required to run the demo.\nPlease install it, e.g., with 'conda install ffmpeg' or with your OS's package manager."
+        )
+        sys.exit(1)
+
+
 def create_demo_app(
     text_to_spec_model_path,
     spec_to_wav_model_path,
@@ -90,6 +104,7 @@ def create_demo_app(
     output_dir,
     accelerator,
 ) -> gr.Blocks:
+    require_ffmpeg()
     device = get_device_from_accelerator(accelerator)
     vocoder_ckpt = torch.load(spec_to_wav_model_path, map_location=device)
     vocoder_model, vocoder_config = load_hifigan_from_checkpoint(vocoder_ckpt, device)

--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -142,7 +142,7 @@ r() {
 
 set -o errexit
 
-r conda create -y $ENV_OPTION python=$PYTHON_VERSION
+r conda create -y $ENV_OPTION python=$PYTHON_VERSION ffmpeg
 eval "$(conda shell.bash hook)"
 r conda activate "$ENV2ACTIVATE"
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make sure ffmpeg is installed, and error out for a clear message if not

two changes:
 - `make-everyvoice-env` now just always installs ffmpeg
 - `everyvoice demo` exits right away if ffmpeg is not found, since we know we'll crash when the user eventually clicks on `synthesize`

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixed #527

### Feedback sought? <!-- What should reviewers focus on in particular? -->

general validation

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no, because we don't have any CI for `everyvoice demo` at the moment.

### How to test? <!-- Explain how reviewers should test this PR. -->

1) get yourself an environment where ffmpeg is not installed (`which ffmpeg` will return nothing) and run `everyvoice demo fp.ckpt vocoder.ckpt` and see it exit with clear instructions.

2) create a new environment with `make-everyvoice-env` and see that `which ffmpeg` is right in your conda env.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

I tested this thoroughly, with ffmpeg not on my path, and with ffmpeg on my path but corrupted (and thus not runnable) and you get the error message each time, whereas with a good ffmpeg things proceed normally.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->



<!-- Add any other relevant information here -->
