### PR TITLE
multiple patches to the new-project wizard

### DIFF
--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -246,7 +246,7 @@ class CLITest(TestCase):
             self.assertEqual(result.exit_code, 1)
             self.assertIn(
                 "We are expecting a FastSpeech2Config but it looks like you provided a DFAlignerConfig",
-                output[0],
+                "\n".join(output),
             )
 
     def test_expensive_imports_are_tucked_away(self):

--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -475,7 +475,7 @@ class WizardTest(TestCase):
         text_processing_step = find_step(SN.text_processing_step, tour.steps)
         # 0 is lowercase, 1 is NFC Normalization, select none
         with monkeypatch(dataset, "tqdm", lambda seq, desc: seq):
-            with patch_menu_prompt([]):
+            with patch_menu_prompt(None):
                 text_processing_step.run()
         self.assertEqual(
             text_processing_step.state["filelist_data_list"][3][2],
@@ -1048,7 +1048,7 @@ class WizardTest(TestCase):
                     ),
                     StepAndAnswer(
                         dataset.SoxEffectsStep(state_subset="dataset_0"),
-                        patch_menu_prompt([]),
+                        patch_menu_prompt(None),
                     ),
                     StepAndAnswer(
                         dataset.DatasetNameStep(state_subset="dataset_0"),
@@ -1380,22 +1380,19 @@ class WizardTest(TestCase):
                             patch_menu_prompt(())
                         ),  # no text preprocessing
                         RecursiveAnswers(
-                            null_patch(),  # skip the question about a speaker column in the data since its festival
+                            null_patch(),  # no speaker column Q for festival format
                             children_answers=[
                                 RecursiveAnswers(
-                                    patch_menu_prompt(
-                                        1
-                                    ),  # want to specify the speaker ID
+                                    patch_menu_prompt(1),  # will specify the speaker ID
                                     children_answers=[
-                                        RecursiveAnswers(
-                                            patch_input("default_speaker")
-                                        )  # new speaker ID
+                                        # new speaker ID
+                                        RecursiveAnswers(patch_input("default_speaker"))
                                     ],
                                 ),
                             ],
                         ),
                         RecursiveAnswers(
-                            null_patch(),  # skip the question about a language column in the data since its festival
+                            null_patch(),  # no language column Q for festival format
                             children_answers=[
                                 RecursiveAnswers(
                                     patch_menu_prompt(0),  # "und" lang selection

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -686,17 +686,14 @@ def get_iso_code(language):
 class TextProcessingStep(Step):
     DEFAULT_NAME = StepNames.text_processing_step
     process_lookup = {
-        0: {"fn": lower, "desc": "lowercase"},
+        0: {"fn": lower, "desc": "Lowercase"},
         1: {"fn": nfc_normalize, "desc": "NFC Normalization"},
     }
 
     def prompt(self):
         return get_response_from_menu_prompt(
-            prompt_text=f"Which of the following text transformations would like to apply to your dataset's {self.state[StepNames.filelist_text_representation_step]}?",
-            choices=(
-                "Lowercase",
-                "NFC Normalization - See here for more information: https://withblue.ink/2019/03/11/why-you-need-to-normalize-unicode-strings.html",
-            ),
+            prompt_text=f"Which of the following text transformations would like to apply to your dataset's {self.state[StepNames.filelist_text_representation_step]}? See https://withblue.ink/2019/03/11/why-you-need-to-normalize-unicode-strings.html for information about NFC normalization.",
+            choices=([process["desc"] for process in self.process_lookup.values()]),
             multi=True,
             return_indices=True,
         )

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -835,6 +835,7 @@ class SymbolSetStep(Step):
                 character_graphemes.update(guess_graphemes_in_text(item["characters"]))
             if "phones" in item:
                 phone_graphemes.update(guess_ipa_phones_in_text(item["phones"]))
+        character_graphemes.discard(" ")  # we don't want the space as a grapheme
         if not phone_graphemes and not character_graphemes:
             return
         punctuation = Punctuation().all

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -157,9 +157,6 @@ class FilelistFormatStep(Step):
         return get_response_from_menu_prompt(
             prompt_text="Select which format your filelist is in:",
             choices=("psv", "tsv", "csv", "festival"),
-            multi=False,
-            search=False,
-            return_indices=False,
         )
 
     def looks_like_sv(self, file_type, separator) -> bool:
@@ -359,9 +356,6 @@ class FilelistTextRepresentationStep(Step):
         return get_response_from_menu_prompt(
             prompt_text=f"Which representation is your text in? Choose '{DatasetTextRepresentation.ipa_phones.value}' if your text data only uses International Phonetic Alphabet characters (punctuation is also OK). Choose '{DatasetTextRepresentation.arpabet}' if your text data uses all ARPABET (punctuation is OK). Choose '{DatasetTextRepresentation.characters}' otherwise.",
             choices=self.text_representation_options,
-            multi=False,
-            search=False,
-            return_indices=False,
         )
 
     def validate(self, response):
@@ -405,8 +399,6 @@ class HeaderStep(Step):
         response = get_response_from_menu_prompt(
             prompt_text=self.prompt_text,
             choices=choices,
-            multi=False,
-            search=False,
             return_indices=True,
         )
         return choice_indices[response]
@@ -526,8 +518,6 @@ class KnowSpeakerStep(Step):
         return get_response_from_menu_prompt(
             choices=self.choices,
             title=f"Since your data does not have a speaker column, we will use a default ID of 'speaker_{self.dataset_index}'. Would you like to specify an alternative speaker ID for this dataset instead?",
-            multi=False,
-            search=False,
         )
 
     def validate(self, response):
@@ -625,7 +615,6 @@ class SelectLanguageStep(Step):
         return get_response_from_menu_prompt(
             choices=supported_langs_choices,
             title="Which of the following supported languages is the language of your dataset?",
-            multi=False,
             search=True,
         )
 
@@ -709,7 +698,6 @@ class TextProcessingStep(Step):
                 "NFC Normalization - See here for more information: https://withblue.ink/2019/03/11/why-you-need-to-normalize-unicode-strings.html",
             ),
             multi=True,
-            search=False,
             return_indices=True,
         )
 
@@ -790,7 +778,6 @@ class SoxEffectsStep(Step):
                 "Remove Silence throughout",
             ),
             multi=True,
-            search=False,
             return_indices=True,
         )
 

--- a/everyvoice/wizard/prompts.py
+++ b/everyvoice/wizard/prompts.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Union
+from typing import Iterable, Sequence
 
 import simple_term_menu
 from questionary import Style
@@ -27,21 +27,30 @@ CUSTOM_QUESTIONARY_STYLE = Style(
 
 def get_response_from_menu_prompt(
     prompt_text: str = "",
-    choices: tuple[str, ...] = (),
+    choices: Sequence[str] = (),
     title: str = "",
     multi=False,
     search=False,
     return_indices=False,
-) -> Union[int, str, list[int], list[str]]:
+) -> str | int | Iterable[str] | Iterable[int]:
     """Given some prompt text and a list of choices, create a simple terminal window
        and return the index of the choice
 
     Args:
-        prompt_text (str): rich prompt text to print before menu
-        choices (list[str]): choices to display
+        prompt_text: rich prompt text to print in a Panel before the menu
+        choices: choices to display
+        title: plain text title to display before the menu (after prompt_text, if given)
+        multi: if set, asks for multiple selections and returns an Interable of them
+        search: if set, allow the user to search through the options with /
+        return_indices: if set, return selected choice index(ices) instead of value(s)
 
     Returns:
-        int: index of choice
+        multi | return_indices | returns
+        ----- | -------------- | -------
+        false | false          | str: choice selected
+        false | true           | int: index of choice selected
+        true  | false          | Iterable[str]: choices selected
+        true  | true           | Iterable[int]: indices of choices selected
     """
     if prompt_text:
         print(Panel(prompt_text))
@@ -56,12 +65,17 @@ def get_response_from_menu_prompt(
         show_search_hint=search,
         status_bar_style=("fg_gray", "bg_black"),
     )
-    index = menu.show()
+    selection = menu.show()
     sys.stdout.write("\033[K")
-    if index is None or return_indices:
-        return index
-    else:
-        if isinstance(index, tuple):
-            return [choices[i] for i in index]
+    if multi:
+        if selection is None:
+            return ()
+        elif return_indices:
+            return selection
         else:
-            return choices[index]
+            return [choices[i] for i in selection]
+    else:
+        if return_indices:
+            return selection
+        else:
+            return choices[selection]


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Multiple improvements and fixes to the new-project wizard.

### Fixes?

Fix the problem where the wizard would include `''` in `test_characters` and thus make `everyvoice train text-to-spec` fail.

Fix the problem where the wizard crashes if you select no text transformations.

Make sure the URL for documentation of NFC normalization is fully legible even when your terminal is not super wide.

Other side improvements to the wizard at the same time.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

regular review

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

High because at the moment, the wizard is broken, 
 - adding `''` to `test_characters` in `config/everyvoice-shared-text.yaml`, which causes a failure when you run `everyvoice train text-to-spec`;
 - crashing if you select no text transformations.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yup

### How to test? <!-- Explain how reviewers should test this PR. -->

run the wizard and see:
 - the URL for NFC normalization is now fully on your screen (used to get truncated unless you screen was very wide)
 - `test_characters` no longer contains `''`
 - no longer get a crash when you pick no text transformations

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

This was part of #530 but it was too big so I spliced it out, so different work can be reviewed separately.

<!-- Add any other relevant information here -->
