### PR TITLE
Display "Loading x" messages as the EV apps start

### DIFF
--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -20,6 +20,10 @@ from loguru import logger
 from pydantic import ValidationError
 from tqdm import tqdm
 
+# This is where we start loading expensive stuff for most CLI commands: give the
+# user a signal that's immediately visible so they know something's happening.
+logger.info("Loading everyvoice package and dependencies")
+
 from everyvoice.config.type_definitions import TargetTrainingTextRepresentationLevel
 from everyvoice.exceptions import InvalidConfiguration
 from everyvoice.model.aligner.config import DFAlignerConfig

--- a/everyvoice/dataloader/__init__.py
+++ b/everyvoice/dataloader/__init__.py
@@ -2,6 +2,9 @@ import os
 from pathlib import Path
 from typing import Callable, Optional, Union
 
+from loguru import logger
+
+logger.info("Loading pytorch_lightning")
 import pytorch_lightning as pl
 import torch
 from torch.utils.data import DataLoader

--- a/everyvoice/demo/app.py
+++ b/everyvoice/demo/app.py
@@ -1,10 +1,17 @@
 import os
 from functools import partial
 
+from loguru import logger
+
+logger.info("Loading gradio")
 import gradio as gr
+
+logger.info("Loading torch")
 import torch
 
 from everyvoice.config.type_definitions import TargetTrainingTextRepresentationLevel
+
+logger.info("Loading fs2")
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.synthesize import (
     synthesize_helper,
 )

--- a/everyvoice/preprocessor/preprocessor.py
+++ b/everyvoice/preprocessor/preprocessor.py
@@ -5,6 +5,10 @@
 - extracts inputs (ex. phonological feats)
 """
 
+from loguru import logger
+
+logger.info("Loading everyvoice preprocessor")
+
 import functools
 import json
 import multiprocessing as mp
@@ -22,7 +26,6 @@ import torch
 import torchaudio
 from clipdetect import detect_clipping
 from joblib import Parallel, delayed
-from loguru import logger
 from rich import print as rich_print
 from rich.panel import Panel
 from rich.style import Style

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ plugins = pydantic.mypy, numpy.typing.mypy_plugin
 check_untyped_defs = False
 
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E402, E501, W503
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Currently, when you start a number of EV commands, there's nothing on screen for quite a while with no feedback telling the user we're starting to work on it.

This PR provides helpful "Loading xyz" messages at several key points where the delays can be long.

Affected:
 - `everyvoice demo`
 - `everyvoice train`
 - `everyvoice synthesize`
 - `everyvoice preprocess`
 - and every other command that ends up importing `everyvoice.base_cli.helpers`

### Feedback sought? <!-- What should reviewers focus on in particular? -->

If find these messages helpful. (I really do!)

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Except for app.py, this was all previously covered, and it seems unnecessary assert anything about info messages.

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the commands listed above and see the new info Loading messages.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/FastSpeech2_lightning/pull/85

<!-- Add any other relevant information here -->
