### PR TITLE
chore: dependency maintenance to allow g2p 2.1

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,6 @@ black~=24.3
 flake8>=4.0.1
 gitlint-core>=0.19.0
 isort>=5.10.1
-matplotlib-stubs==0.2.0
 mypy>=1.8.0
 pre-commit>=2.6.0
 types-pyyaml>=6.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,17 @@ clipdetect>=0.1.4
 deepdiff>=6.5.0
 anytree>=2.12.1
 einops==0.5.0
-g2p~=2.0.0
+g2p~=2.0
 gradio>=4.32.1
 grapheme>=0.6.0
 ipatok>=0.4.1
 librosa==0.9.2
 lightning>=2.0.0
 loguru==0.6.0
-matplotlib==3.6.0
+matplotlib~=3.9.0
 merge-args
 nltk==3.9.1
+numpy<2  # torch < 2.4.1 requires numpy < 2 but fails to declare it
 pandas~=2.0
 panphon==0.20.0
 protobuf~=4.25  # https://github.com/EveryVoiceTTS/EveryVoice/issues/387


### PR DESCRIPTION
also:
 - bump matplotlib to the current version, already bundled with type hints
 - declare numpy < 2 since torch < 2.4.1 requires it without declaring it

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Allow g2p 2.1.0 with EveryVoice

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### How to test? <!-- Explain how reviewers should test this PR. -->

CI test suites should do

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high
