### PR TITLE
Resume at the end of the last trained epoch

### DIFF
--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -243,6 +243,7 @@ def train_base_command(
         every_n_train_steps=config.training.ckpt_steps,
         every_n_epochs=config.training.ckpt_epochs,
         enable_version_counter=True,
+        save_on_train_epoch_end=True,
     )
     # This callback will only save the top-k checkpoints
     # based on minimization of the monitored loss


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix proper resuming of `text-to-spec` training.
The state at the end of the last epoch wasn't saved and resuming would be performed from the last saved checkpoint that was the last checkpoint used for validation.  This was producing staggered runs as shown in `tensorboard`.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

#534 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

merge approval

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None

### How to test? <!-- Explain how reviewers should test this PR. -->

```sh
   srun everyvoice train text-to-spec \
      config/everyvoice-text-to-spec.yaml \
      --config-args training.max_epochs=1 \
```

Check the state of the loops
```sh
python -c 'import torch; import json; m = torch.load("logs_and_checkpoints/FeaturePredictionExperiment/save_on_train_epoch_end/checkpoints/last.ckpt", map_location=torch.device("cpu")); print(json.dumps(m["loops"]["fit_loop"]["epoch_loop.batch_progress"], indent=2))'
```
Which will yield something like the following.  You want to look at `current`'s values.  This run used 11790 training examples split across batches of 16 examples thus, one epoch is 11790/16 ~ 736 batches per epoch.  If, instead, we see 500, the default `val_check_interval`, this would mean that we didn't save at the end of the epoch.
```json
{
  "total": {
    "ready": 4421,
    "completed": 4421,
    "started": 4421,
    "processed": 4421
  },
  "current": {
    "ready": 736,
    "completed": 736,
    "started": 736,
    "processed": 736
  },
  "is_last_batch": true
}
```

Try resuming for a second epoch.
```sh
   srun everyvoice train text-to-spec \
      config/everyvoice-text-to-spec.yaml \
      --config-args training.finetune_checkpoint="logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt" \
      --config-args training.max_epochs=2 \
```

Use `tensorboard` and check that the second run's training is NOT staggered with your first run.

```sh
tensorboard --port=2024 --logdir=logs_and_checkpoints  --bind_all
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Good

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

None

<!-- Add any other relevant information here -->
