### PR TITLE
allow synthesis with only the generator. add everyvoice export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,10 @@ jobs:
           if pip-licenses | grep -E -v 'Artistic License|LGPL|Public Domain' | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
       - uses: tj-actions/changed-files@v45
         id: file_changes
+        with:
+          # Only run pre-commit on EV files themselves, not on submodules
+          # See https://github.com/EveryVoiceTTS/EveryVoice/issues/555
+          exclude_submodules: true
       - name: Custom replacement for pre-commit/action
         # pre-commit/action is not compatible with conda-incubator/setup-miniconda because it sets the shell wrong.
         run: python -m pre_commit run --show-diff-on-failure --color=always --files ${{ steps.file_changes.outputs.all_changed_files }}

--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -24,6 +24,9 @@ from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.train imp
     train as train_fs2,
 )
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import (
+    export as export_hfg,
+)
+from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import (
     synthesize as synthesize_hfg,
 )
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import train as train_hfg
@@ -230,6 +233,40 @@ class ModelTypes(str, Enum):
     text_to_spec = "text-to-spec"
     spec_to_wav = "spec-to-wav"
 
+
+# Add the export commands
+export_group = typer.Typer(
+    pretty_exceptions_show_locals=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    rich_markup_mode="markdown",
+    cls=TyperGroupOrderAsDeclared,
+    help="""
+    # Export Help
+
+        - **spec-to-wav** --- You can export your spec-to-wav model to a much smaller format for synthesis. Advanced: this will export only the generator, leaving the weights of the discriminators behind.
+    """,
+)
+
+export_group.command(
+    short_help="Export and optimize a spec-to-wav model for inference",
+    name="spec-to-wav",
+    help="""Export your spec-to-wav model.
+
+    # Important!
+
+    This will reduce the size of your checkpoint but it means that the exported checkpoint cannot be resumed for training, it can only be used for inference/synthesis.
+
+    For example:
+
+    **everyvoice export spec-to-wav <path_to_ckpt> <output_path>**
+    """,
+)(export_hfg)
+
+app.add_typer(
+    export_group,
+    name="export",
+    short_help="Export your EveryVoice models",
+)
 
 app.command(
     short_help="Segment a long audio file",


### PR DESCRIPTION
allow synthesis with only the generator checkpoint

fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/424

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This PR allows users to "export" vocoder models (`everyvoice export`) which trims down the model by removing the discriminators. It also allows loading the vocoder model and inference/synthesis (not training) using only the generator. This allows us to distribute 50MB files instead of 950MB files when all people want to do is synthesize (not fine-tune/resume training)

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

https://github.com/EveryVoiceTTS/EveryVoice/issues/424

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanitty

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high - alpha 4

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Again, we do not have tests for inference unfortunately

### How to test? <!-- Explain how reviewers should test this PR. -->

take an existing vocoder and run `everyvoice export <path_to_vocoder.ckpt>` then try synthesizing using the generated `exported.ckpt` checkpoint.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium-high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

yes, alpha 4

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/HiFiGAN_iSTFT_lightning/pull/34

<!-- Add any other relevant information here -->
