### PR TITLE
fix: resolve tilde in paths in wizard

### DIFF
--- a/everyvoice/wizard/__init__.py
+++ b/everyvoice/wizard/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from enum import Enum
 from typing import Optional, Sequence
@@ -40,6 +41,14 @@ class _Step:
         """
         Perform data sanitization of user provided input.
         """
+        return response
+
+    def sanitize_paths(self, response):
+        """For steps that return path, have sanitize_input call sanitize_paths"""
+        # Remove surrounding whitespace
+        response = response.strip()
+        # Support ~ and ~username path expansions
+        response = os.path.expanduser(response)
         return response
 
     def validate(self, response) -> bool:

--- a/everyvoice/wizard/basic.py
+++ b/everyvoice/wizard/basic.py
@@ -138,8 +138,7 @@ class OutputPathStep(Step):
         ).unsafe_ask()
 
     def sanitize_input(self, response):
-        response = super().sanitize_input(response)
-        return response.strip()
+        return self.sanitize_paths(response)
 
     def validate(self, response) -> bool:
         path = Path(response)

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -91,8 +91,7 @@ class WavsDirStep(Step):
         ).unsafe_ask()
 
     def sanitize_input(self, response):
-        response = super().sanitize_input(response)
-        return response.strip()
+        return self.sanitize_paths(response)
 
     def validate(self, response) -> bool:
         valid_path = validate_path(response, is_dir=True, exists=True)
@@ -142,8 +141,7 @@ class FilelistStep(Step):
         ).unsafe_ask()
 
     def sanitize_input(self, response):
-        response = super().sanitize_input(response)
-        return response.strip()
+        return self.sanitize_paths(response)
 
     def validate(self, response) -> bool:
         return validate_path(response, is_file=True, exists=True)


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->

Support `~` and `~username` in wizard. This is particularly important because questionary.path allows using tilde, but then our code didn't expand it so an anto-completed path would not work in the end.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #539

### Feedback sought? <!-- What should reviewers focus on in particular? -->

approval

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high - milestone a4

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

I had not, but this question make me go back and add them... 😄 

### How to test? <!-- Explain how reviewers should test this PR. -->

run the wizard and use ~ or ~username in path-related questions

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
