### PR TITLE
fix: display less confusing reports in preprocessing

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -731,8 +731,8 @@ class WizardTest(TestCase):
         with patch_menu_prompt((1, 2, 3, 0), multi=True) as stdout:
             format_step.run()
         output = re.sub(r" *\n", " ", stdout.getvalue())
-        self.assertRegex(output, "does not look like a .*'tsv'")
-        self.assertRegex(output, "does not look like a .*'csv'")
+        self.assertRegex(output, r"does not look like a .*'tsv'".replace(" ", r"\s"))
+        self.assertRegex(output, r"does not look like a .*'csv'".replace(" ", r"\s"))
         self.assertIn("is not in the festival format", output)
         self.assertTrue(format_step.completed)
         # print(format_step.state)
@@ -755,9 +755,9 @@ class WizardTest(TestCase):
         with patch_menu_prompt((0, 1, 2, 3), multi=True) as stdout:
             format_step.run()
         output = stdout.getvalue().replace(" \n", " ")
-        self.assertRegex(output, "does not look like a .*'psv'")
-        self.assertRegex(output, "does not look like a .*'tsv'")
-        self.assertRegex(output, "does not look like a .*'csv'")
+        self.assertRegex(output, r"does not look like a .*'psv'".replace(" ", r"\s"))
+        self.assertRegex(output, r"does not look like a .*'tsv'".replace(" ", r"\s"))
+        self.assertRegex(output, r"does not look like a .*'csv'".replace(" ", r"\s"))
         self.assertTrue(format_step.completed)
         # print(format_step.state)
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Reduce the confusion from the two nearly identical reports printed during `everyvoice preprocess`.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #342

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

already covered by existing tests

### How to test? <!-- Explain how reviewers should test this PR. -->

Run `everyvoice preprocess config/everyvoice-text-to-spec.yaml` and see:
 - The first report is labelled partial, and omits missing symbols, skipped processes, and nans, which are not related to audio-processing.
 - The second report is like before, with this elements included.
 
### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium-high

### Question

The `nans` line in the report is never actually populated. What's it supposed to count? should `_interpolate()` or `extract_pitch()` update it?




<!-- Add any other relevant information here -->
