### PR TITLE
test: exercise finding wavs in nested symlink structures

### DIFF
--- a/everyvoice/tests/test_preprocessing.py
+++ b/everyvoice/tests/test_preprocessing.py
@@ -494,7 +494,7 @@ class PreprocessingTest(PreprocessedAudioFixture, BasicTestCase):
         lj_preprocessed = tmpdir / "preprocessed"
         lj_filelist = lj_preprocessed / "preprocessed_filelist.psv"
 
-        fp_config = FeaturePredictionConfig(contact=self.contact)
+        fp_config = FeaturePredictionConfig(contact=self.contact)  # type: ignore
         fp_config.preprocessing.source_data[0].data_dir = self.data_dir / "lj" / "wavs"
 
         full_filelist = self.data_dir / "metadata.psv"

--- a/everyvoice/tests/test_preprocessing.py
+++ b/everyvoice/tests/test_preprocessing.py
@@ -669,6 +669,35 @@ class PreprocessingTest(PreprocessedAudioFixture, BasicTestCase):
             config = PreprocessingConfig(train_split=1.1)
             self.assertIn("Input should be less than or equal to 1", cout.getvalue())
 
+    def test_no_speaker(self):
+        """Exercise getting the defalut speaker and languages during preprocessing"""
+        # This doesn't really happen anymore because the wizard inserts speaker_0 by
+        # default, or the user's selected default speaker name, and the wizard inserts
+        # the language selected, but since we still support missing those columns, we
+        # want to test that here.
+        self.assertEqual(
+            self.preprocessor.get_speaker_and_language({"item": "foo"}),
+            {"item": "foo", "speaker": "default", "language": "default"},
+        )
+        self.assertEqual(
+            self.preprocessor.get_speaker_and_language(
+                {"item": "foo", "language": "bar"}
+            ),
+            {"item": "foo", "speaker": "default", "language": "bar"},
+        )
+        self.assertEqual(
+            self.preprocessor.get_speaker_and_language(
+                {"item": "foo", "speaker": "baz"}
+            ),
+            {"item": "foo", "speaker": "baz", "language": "default"},
+        )
+        self.assertEqual(
+            self.preprocessor.get_speaker_and_language(
+                {"item": "foo", "language": "bar", "speaker": "baz"}
+            ),
+            {"item": "foo", "speaker": "baz", "language": "bar"},
+        )
+
 
 class PreprocessingHierarchyTest(BasicTestCase):
     def test_hierarchy(self):


### PR DESCRIPTION
Fixes #89

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Unit test our glob code to make sure it works with deep symlink structures.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixed #89

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

nothing but!

### How to test? <!-- Explain how reviewers should test this PR. -->

If you change `WavsDirStep.validate()` to use `contains_wavs = next(path_expanded.glob("**/*.wav"), False)` instead of the current code, you'll see that `test_wizard` will fail on this new test function, but it passes with the current code.

```sh
python -m unittest \
  everyvoice.tests.test_preprocessing.PreprocessingTest.test_no_speaker \
  everyvoice.tests.test_wizard.WizardTest.test_wavs_dir
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
