### PR TITLE
fix: reconfigure flake8; it does not support pyproject.toml

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 88
+max-complexity = 18
+select = B, C, E, F, W, T4, B9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,12 +115,6 @@ Repository = "https://github.com/EveryVoiceTTS/EveryVoice"
 Issues = "https://github.com/EveryVoiceTTS/EveryVoice/issues"
 Changelog = "https://github.com/EveryVoiceTTS/EveryVoice/releases"
 
-[tool.flake8]
-ignore = ["E203", "E266", "E501", "W503"]
-max-line-length = 88
-max-complexity = 18
-select = ["B", "C", "E", "F", "W", "T4", "B9"]
-
 [tool.hatch.version]
 path = "everyvoice/_version.py"
 # pattern = "VERSION = 'b(?P<version>[^']+)'"


### PR DESCRIPTION
Refs:
 - https://github.com/PyCQA/flake8/issues/234
 - https://flake8.pycqa.org/en/latest/user/configuration.html

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

The flake8 configuration done in `pyproject.toml` is ineffective, because flake8 just does not support that, so all the previously ignored warnings and the rest of our configuration are suddenly ignored.

This PR restores our previous flake8 config.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

testing I guess

question: do we want this in `.flake8` or in `setup.cfg`? I didn't use the latter because it would be the only tool we configure in there.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Before merging #582 I guess, so CI can pass for that PR.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Running `pre-commit run --all` should show no warnings from flake8. It will show lots of issues from black (#582 will fix that) and mypy, please ignore those for the purpose of this PR which only touches flake8.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

