### PR TITLE
Making minimal sized `sdist` and `whl` using pyproject.toml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,9 +31,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install pypa/build
-        run: python3 -m pip install build
+        run: python3 -m pip install hatch
       - name: Build a binary wheel and a source tarball
-        run: python -m build --sdist --wheel
+        run: hatch build
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ path = "everyvoice/_version.py"
 # pattern = "VERSION = 'b(?P<version>[^']+)'"
 
 [tool.hatch.build.targets.sdist]
-include = ["requirements.torch.txt", "/everyvoice"]
+include = ["/everyvoice"]
 exclude = [
   "*.coveragerc",
   "*.ipynb",
@@ -143,8 +143,7 @@ exclude = [
 ]
 
 [tool.hatch.build.targets.wheel]
-# sources = ["/everyvoice"]
-include = ["requirements.torch.txt", "/everyvoice"]
+include = ["/everyvoice"]
 exclude = [
   "*.coveragerc",
   "*.ipynb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
   "PyYAML>=5.1",
   "questionary==1.10.0",
   "simple-term-menu==1.5.2",
-  "setuptools==75.4.0",
   "tabulate==0.9.0",
   "tensorboard>=2.14.1",
   "torch==2.1.0",
@@ -118,6 +117,54 @@ Changelog = "https://github.com/EveryVoiceTTS/EveryVoice/releases"
 [tool.hatch.version]
 path = "everyvoice/_version.py"
 # pattern = "VERSION = 'b(?P<version>[^']+)'"
+
+[tool.hatch.build.targets.sdist]
+include = ["requirements.torch.txt", "/everyvoice"]
+exclude = [
+  "*.coveragerc",
+  "*.ipynb",
+  "*.psv",
+  "*.pyc",
+  "*/.schema/*.json",
+  "*~",
+  ".git",
+  ".github",
+  ".gitlint",
+  ".pre-commit-config.yaml",
+  "LICENSE",
+  "README.md",
+  "pyproject.toml",
+  "readme.md",
+  "requirement*txt",
+  "setup.cfg",
+  "setup.py",
+  "tests/",
+  # ".gitignore",  # Needed/Used by hatch to filter-out files
+]
+
+[tool.hatch.build.targets.wheel]
+# sources = ["/everyvoice"]
+include = ["requirements.torch.txt", "/everyvoice"]
+exclude = [
+  "*.coveragerc",
+  "*.ipynb",
+  "*.psv",
+  "*.pyc",
+  "*/.schema/*.json",
+  "*~",
+  ".git",
+  ".github",
+  ".gitignore",
+  ".gitlint",
+  ".pre-commit-config.yaml",
+  "LICENSE",
+  "README.md",
+  "readme.md",
+  "requirement*txt",
+  "setup.cfg",
+  "setup.py",
+  "tests/",
+]
 
 [tool.isort]
 known_first_party = "everyvoice"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Turns out that our understanding of `pyproject.toml` with `hatch` was insufficient.
This PR aims to reduce what is included in a `sdist` and `whl`.
We decided to remove all `tests/` because they would require us to include the wav files and more which bloats the `whl` and `sdist`.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

fixes: #586 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

This PR as a long and explicit list of inclusions and exclusions, is this the best way of doing what we want to achieve?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Needed before our next release

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None

### How to test? <!-- Explain how reviewers should test this PR. -->

Get yourself some reference prebuild `whl` and `sdist` files.

```sh
wget 'https://files.pythonhosted.org/packages/1c/c4/99440963fb2562fcf019d8949400c7467a6c10a524515e81f054cbbcb32a/everyvoice-0.1.0a3-py3-none-any.whl'
wget 'https://files.pythonhosted.org/packages/14/a4/898c980f6ee34ce240efb9f6d3ffbf24ed755497dc52751953ca5a2228e4/everyvoice-0.1.0a3.tar.gz'
```

```sh
hatch build
````

Compare the content of each files with its reference.

## sdist

```sh
vimdiff \
  +':windo %sort' \
  <(tar tf dist/everyvoice-0.2.0a0.tar.gz | sed 's|^[^/]\+/||') \
  <(tar tf everyvoice-0.1.0a3.tar.gz | sed 's|^[^/]\+/||;  /.*\/$/d')
```

```sh
diff \
  <(tar tf everyvoice-0.1.0a3.tar.gz | sed 's|^[^/]\+/||;  /.*\/$/d' | sort) \
  <(tar tf dist/everyvoice-0.2.0a0.tar.gz | sed 's|^[^/]\+/||' | sort)
```

```patch
1d0
<
19,25c18
< everyvoice.egg-info/dependency_links.txt
< everyvoice.egg-info/entry_points.txt
< everyvoice.egg-info/not-zip-safe
< everyvoice.egg-info/PKG-INFO
< everyvoice.egg-info/requires.txt
< everyvoice.egg-info/SOURCES.txt
< everyvoice.egg-info/top_level.txt
---
> everyvoice/evaluation.py
36a30
> everyvoice/model/aligner/DeepForcedAligner/.gitignore
42a37
> everyvoice/model/aligner/wav2vec2aligner/.gitignore
54d48
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/cli/audit.py
56d49
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/cli/check_data.py
71,73d63
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/__init__.py
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/test_cli.py
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/test_writing_callbacks.py
78a69
> everyvoice/model/feature_prediction/FastSpeech2_lightning/.gitignore
82a74
> everyvoice/model/vocoder/HiFiGAN_iSTFT_lightning/.gitignore
95,106d86
< everyvoice/tests/basic_test_case.py
< everyvoice/tests/__init__.py
< everyvoice/tests/preprocessed_audio_fixture.py
< everyvoice/tests/stubs.py
< everyvoice/tests/test_cli.py
< everyvoice/tests/test_configs.py
< everyvoice/tests/test_dataloader.py
< everyvoice/tests/test_model.py
< everyvoice/tests/test_preprocessing.py
< everyvoice/tests/test_text.py
< everyvoice/tests/test_utils.py
< everyvoice/tests/test_wizard.py
121a102
> everyvoice/wizard/simple_term_menu_win_stub.py
123a105
> .gitignore
125d106
< MANIFEST.in
126a108
> pyproject.toml
128,133d109
< requirements.dev.txt
< requirements.test.txt
< requirements.torch.txt
< requirements.txt
< setup.cfg
< setup.py
```

## Wheel

```sh
vimdiff \
  <(unzip -l dist/everyvoice-0.2.0a0-py3-none-any.whl | sed 's|.* ||') \
  <(unzip -l everyvoice-0.1.0a3-py3-none-any.whl | sed 's|.* ||')
```

```sh
diff \
  <(unzip -l everyvoice-0.1.0a3-py3-none-any.whl | sed 's|.* ||' | sort) \
  <(unzip -l dist/everyvoice-0.2.0a0-py3-none-any.whl | sed 's|.* ||' | sort)
```
```patch
diff  <(unzip -l everyvoice-0.1.0a3-py3-none-any.whl | sed 's|.* ||' | sort)  <(unzip -l dist/everyvoice-0.2.0a0-py3-none-any.whl | sed 's|.* ||' | sort)                                    3,9c3,8
< everyvoice-0.1.0a3.dist-info/entry_points.txt
< everyvoice-0.1.0a3.dist-info/LICENSE
< everyvoice-0.1.0a3.dist-info/METADATA
< everyvoice-0.1.0a3.dist-info/RECORD
< everyvoice-0.1.0a3.dist-info/top_level.txt
< everyvoice-0.1.0a3.dist-info/WHEEL
< everyvoice-0.1.0a3-py3-none-any.whl
---
> dist/everyvoice-0.2.0a0-py3-none-any.whl
> everyvoice-0.2.0a0.dist-info/entry_points.txt
> everyvoice-0.2.0a0.dist-info/licenses/LICENSE
> everyvoice-0.2.0a0.dist-info/METADATA
> everyvoice-0.2.0a0.dist-info/RECORD
> everyvoice-0.2.0a0.dist-info/WHEEL
26a26
> everyvoice/evaluation.py
55d54
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/cli/audit.py
57d55
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/cli/check_data.py
72,74d69
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/__init__.py
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/test_cli.py
< everyvoice/model/feature_prediction/FastSpeech2_lightning/fs2/tests/test_writing_callbacks.py
96,107d90
< everyvoice/tests/basic_test_case.py
< everyvoice/tests/__init__.py
< everyvoice/tests/preprocessed_audio_fixture.py
< everyvoice/tests/stubs.py
< everyvoice/tests/test_cli.py
< everyvoice/tests/test_configs.py
< everyvoice/tests/test_dataloader.py
< everyvoice/tests/test_model.py
< everyvoice/tests/test_preprocessing.py
< everyvoice/tests/test_text.py
< everyvoice/tests/test_utils.py
< everyvoice/tests/test_wizard.py
122a106
> everyvoice/wizard/simple_term_menu_win_stub.py
```

## Access to the unittest

After making a new environment with `make-everyvoice-env`, we can still perform `python -m unittest everyvoice.tests.test_dataloader` even if the `tests/` directory wasn't included in the `whl`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

fair

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

None

<!-- Add any other relevant information here -->
