### PR TITLE
fix: exported model name should match generator class name

### DIFF
--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -37,6 +37,10 @@ from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.train imp
     train as train_fs2,
 )
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import (
+    HFG_EXPORT_LONG_HELP,
+    HFG_EXPORT_SHORT_HELP,
+)
+from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import (
     export as export_hfg,
 )
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.cli import (
@@ -311,18 +315,9 @@ export_group = typer.Typer(
 )
 
 export_group.command(
-    short_help="Export and optimize a spec-to-wav model for inference",
+    short_help=HFG_EXPORT_SHORT_HELP,
     name="spec-to-wav",
-    help="""Export your spec-to-wav model.
-
-    # Important!
-
-    This will reduce the size of your checkpoint but it means that the exported checkpoint cannot be resumed for training, it can only be used for inference/synthesis.
-
-    For example:
-
-    **everyvoice export spec-to-wav <path_to_ckpt> <output_path>**
-    """,
+    help=HFG_EXPORT_LONG_HELP,
 )(export_hfg)
 
 app.add_typer(
@@ -514,7 +509,7 @@ train_group.command(
 train_group.command(
     name="spec-to-wav",
     short_help="Train your Spec-to-Wav model",
-    help=f"""Train your spec-to-wav model. For example:
+    help=f"""Train your spec-to-wav model.  For example:
 
     **everyvoice train spec-to-wav config/{SPEC_TO_WAV_CONFIG_FILENAME_PREFIX}.yaml**
     """,


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

When you run `everyvoice export` the vocoder HiFiGAN is exported as a HiFiGANGenerator which then breaks the model name validation. 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

I just fixed the bug before creating an issue report since I just noticed it this weekend.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

@SamuelLarkin - I'm not sure if the quick fix I've done here is the best way of addressing this, can you please advise if there is another place I should address the fix?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high - currently demos are broken with exported vocoders

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

I can't really test the exporting of a model because of the size of the vocoder model (1GB)

### How to test? <!-- Explain how reviewers should test this PR. -->



### Confidence? <!-- How confident are you that these changes are ready to merge? -->



### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/HiFiGAN_iSTFT_lightning/pull/42

<!-- Add any other relevant information here -->
