### PR TITLE
ci: simplify CI EV install, use apt-get, remove conda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,27 +12,17 @@ jobs:
     timeout-minutes: 15
     permissions:
       pull-requests: write
-    defaults:
-      run:
-        # Required for conda-incubator/setup-miniconda
-        # https://github.com/conda-incubator/setup-miniconda?tab=readme-ov-file#important
-        shell: bash -l {0}
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
-      - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - run: sudo apt-get install sox libsox-dev ffmpeg
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          miniforge-version: latest
-          conda-remove-defaults: true
-      - uses: FedericoCarboni/setup-ffmpeg@v2
-      - name: Install sox and use conda to optimize other installs
-        run: |
-          conda install -y sox $(grep "pycountry\|pyworld" requirements.txt) -c conda-forge
+          cache: "pip"
       - name: Install dependencies and package
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->


We don't actually need conda, at least not anymore:
 - sox and ffmpeg can be installed with apt-get
 - previously optimized pip installs for pyworld and pycountry can simply be cached by the standard pip caching mechanism, instead of using custom optimizations

The result is a more standard CI workflow, and a tiny bit faster to boot.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Mostly rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

it's just CI

### How to test? <!-- Explain how reviewers should test this PR. -->

look at CI workflows from this branch vs others

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
