### PR TITLE
fix(build): the last ev install in make-env has to be editable

### DIFF
--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -165,8 +165,7 @@ if ! r pip install $PY_COUNTRY_WORLD; then
 fi
 
 r conda install -y sox -c conda-forge
-r pip install -e .
-r pip install .[dev]
+r pip install -e .[dev]
 echo ""
 echo "Environment creation completed with success"
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix make-everyvoice-env, which is currently broken

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

The fact that `pip install .[dev]` effectively undoes the editable installation we do one line up in `make-everyvoice-env`.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping, it's already tested

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

This fails on `origin/main` right now, passes on this branch:
```
./make-everyvoice-env -n test-env
conda activate test-env
everyvoice/run_tests.py
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
