### PR TITLE
ci: run licensecheck to auto-audit our dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,6 @@ jobs:
           # Ignore nvidia-*-cu12 packages used by the GPU back-end: OTHER/PROPRIETARY LICENSE
           licensecheck --zero \
               --ignore-packages text-unidecode pympi-ling pyworld pysdtw audioread \
-              --ignore-licenses OTHER/PROPRIETARY  \
-          | tee licensecheck.txt
+              --ignore-licenses OTHER/PROPRIETARY
           # Only nvidia's and aiohappyeyeballs's proprietary licenses are OK.
-          ! grep -v -E 'nvidia-|aiohappyeyeballs' licensecheck.txt | grep PROPRIETARY
+          ! licensecheck --format csv | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,10 @@ jobs:
           # Ignore nvidia-*-cu12 packages used by the GPU back-end: OTHER/PROPRIETARY LICENSE
           licensecheck --zero \
               --ignore-packages text-unidecode pympi-ling pyworld pysdtw audioread \
-              --ignore-licenses OTHER/PROPRIETARY
+              --ignore-licenses OTHER/PROPRIETARY \
+          || echo "Package(s) listed with an X above is/are potentially a problem."
+
           # Only nvidia's and aiohappyeyeballs's proprietary licenses are OK.
-          ! licensecheck --format csv | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY
+          echo ""
+          ! licensecheck --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY \
+          || echo "The package(s) listed just above this line is/are potentially a problem."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,9 @@ jobs:
       - name: Install dependencies and package
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-          pip install -e .[dev]
-          pip install coverage
+          pip install -e .[dev] coverage
       - run: pip freeze
       - run: pip list
-      - name: Check licenses
-        run: |
-          pip install pip-licenses
-          if pip-licenses | grep -E -v 'Artistic License|LGPL|Public Domain' | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
       - uses: tj-actions/changed-files@v45
         id: file_changes
         with:
@@ -86,3 +81,9 @@ jobs:
         with:
           preformatted: true
           message-path: import-message.txt
+      - name: Check licenses
+        run: |
+          pip install licensecheck --no-warn-conflicts
+          # Make sure we don't have or introduce dependencies with incompatible licenses.
+          # Ignore packages where auto analysis does not work but manual analysis says OK.
+          licensecheck --zero --ignore-packages text-unidecode pympi-ling pyworld pysdtw audioread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,4 +92,4 @@ jobs:
               --ignore-licenses OTHER/PROPRIETARY  \
           | tee licensecheck.txt
           # Only nvidia's and aiohappyeyeballs's proprietary licenses are OK.
-          ! grep -v -E 'nvidia-|aiohapyeyeballs' licensecheck.txt | grep PROPRIETARY
+          ! grep -v -E 'nvidia-|aiohappyeyeballs' licensecheck.txt | grep PROPRIETARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,10 @@ jobs:
           pip install licensecheck --no-warn-conflicts
           # Make sure we don't have or introduce dependencies with incompatible licenses.
           # Ignore packages where auto analysis does not work but manual analysis says OK.
-          licensecheck --zero --ignore-packages text-unidecode pympi-ling pyworld pysdtw audioread
+          # Ignore nvidia-*-cu12 packages used by the GPU back-end: OTHER/PROPRIETARY LICENSE
+          licensecheck --zero \
+              --ignore-packages text-unidecode pympi-ling pyworld pysdtw audioread \
+              --ignore-licenses OTHER/PROPRIETARY  \
+          | tee licensecheck.txt
+          # Only nvidia's and aiohappyeyeballs's proprietary licenses are OK.
+          ! grep -v -E 'nvidia-|aiohapyeyeballs' licensecheck.txt | grep PROPRIETARY


### PR DESCRIPTION
Same as Studio and g2p, but with more exceptions whose licenses are not auto-detected.
