### PR TITLE
fix: let the demo save wav files to disk again

### DIFF
--- a/everyvoice/demo/app.py
+++ b/everyvoice/demo/app.py
@@ -20,6 +20,9 @@ from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.model import 
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.prediction_writing_callback import (
     PredictionWritingWavCallback,
 )
+from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.type_definitions import (
+    SynthesizeOutputFormats,
+)
 from everyvoice.model.vocoder.HiFiGAN_iSTFT_lightning.hfgl.utils import (
     load_hifigan_from_checkpoint,
 )
@@ -73,7 +76,7 @@ def synthesize_audio(
         device=device,
         global_step=1,
         vocoder_global_step=1,  # dummy value since the vocoder step is not used
-        output_type=[],
+        output_type=[SynthesizeOutputFormats.wav],
         text_representation=TargetTrainingTextRepresentationLevel.characters,
         output_dir=output_dir,
         speaker=speaker,


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Working on https://github.com/EveryVoiceTTS/EveryVoice/issues/478 I noticed that the demo no longer outputs .wav files at all.

This PR restores just that functionality, minimally.

It doesn't address the question of the `.pth` file that gets generated, and that ignores the directory specified with `-o`.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

I don't like this solution, because the wav writer callback gets created twice, one that gets called by the pytorch_lightning/trainer and another that gets instantiated and called directly in demo/app.

I would like to find a solution where
 - only one callback is created, and reused in the two places
 - even better, `synthesize_audio()` is only called once and its output is reused

But for the moment the question is, is this simple solution good enough for now?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta I guess, and whenever we want to have a demo that saves generated audio files.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no, unfortunately we have no demo tests. But #611 is my next priority and I hope I'll find a way to exercise the demo in that regression suite.

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the demo

    everyvoice demo fs2.cpkt voc.cpkt

and see the wav files generated in `synthesis_output/wav` again, or in `dir/wav` if you specify `-o dir`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

both high and low.

high: this PR gets .wav files generated

low: I don't like the solution

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
