### PR TITLE
fix: move torch forward to 2.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ dependencies = [
   "simple-term-menu==1.5.2",
   "tabulate==0.9.0",
   "tensorboard>=2.14.1",
-  "torch==2.1.0",
-  "torchaudio==2.1.0",
+  "torch==2.3.1",
+  "torchaudio==2.3.1",
   "torchinfo==1.8.0",
   "typer>=0.12.4",
   "yaspin>=3.1.0",
@@ -84,8 +84,8 @@ dynamic = ["version"]
 torch = [
   # these requirements have to be installed ahead of time in your environment and from a different URL:
   # CUDA_TAG=cu118 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-  'torch==2.1.0; sys_platform == "darwin"',
-  'torchaudio==2.1.0; sys_platform == "darwin"',
+  'torch==2.3.1; sys_platform == "darwin"',
+  'torchaudio==2.3.1; sys_platform == "darwin"',
 ]
 dev = [
   "black~=24.3",

--- a/requirements.torch.txt
+++ b/requirements.torch.txt
@@ -1,6 +1,6 @@
 # these requirements have to be installed ahead of time in your environment and from a different URL:
 # CUDA_TAG=cu118 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.1.0; sys_platform == "darwin"
-torchaudio==2.1.0; sys_platform == "darwin"
-torch==2.1.0+${CUDA_TAG}; sys_platform != "darwin"
-torchaudio==2.1.0+${CUDA_TAG}; sys_platform != "darwin"
+torch==2.3.1; sys_platform == "darwin"
+torchaudio==2.3.1; sys_platform == "darwin"
+torch==2.3.1+${CUDA_TAG}; sys_platform != "darwin"
+torchaudio==2.3.1+${CUDA_TAG}; sys_platform != "darwin"


### PR DESCRIPTION
After some good testing by Marc, we can see that the audio quality is comparable with 2.3 and 2.1.

Torch 2.1.0 has vulnerabilities and is no longer available in some environments, so we decided to bump to 2.3.1.

At the EV dev meeting, we decided not to move to 2.4 yet as there is a Future Proofing warning we need to handle first (see #621).

Replaces #521, done in pyproject.toml instead of requirements.txt.

### Fixes

Fixes https://github.com/EveryVoiceTTS/EveryVoice/security/dependabot/2
Fixes https://github.com/EveryVoiceTTS/EveryVoice/security/dependabot/4
Fixes https://github.com/EveryVoiceTTS/EveryVoice/security/dependabot/10
Fixes https://github.com/EveryVoiceTTS/EveryVoice/security/dependabot/11
Fixes #558

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

tested manually

### How to test? <!-- Explain how reviewers should test this PR. -->

make a fresh env and run stuff

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high, since we agreed to this at yesterday's EV meeting

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

coming soon...

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
