### PR TITLE
Dev.ej/update docs only on change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,4 +30,12 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Deploy docs with mike 🚀
         run: |
-          mike deploy --push --update-aliases dev latest
+          mike deploy --update-aliases dev latest
+      - name: Push only if there was a contentful change
+        run: |
+          if git diff --name-only origin/gh-pages gh-pages | grep -v dev/sitemap.xml; then
+            echo Pushing real changes
+            git push origin gh-pages
+          else
+            echo No contentful changes to push
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
           fetch-depth: 0 # fetch all commits/branches
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -89,7 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
           fetch-depth: 0 # fetch all commits/branches
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SGILE_PAT }}
           submodules: recursive
       - run: sudo apt-get install sox libsox-dev ffmpeg
       - uses: actions/setup-python@v5


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Right now, every time we merge a PR to main, the docs get a updated and a commit get pushed to gh-pages. However, most of those comments are not contentful, except for updating that last modified date, which is misleading since the docs was not actually updated.

This PR only pushes the change to gh-pages if they're contentful.

Side change: now that our repos are public, we no longer need to use the SGILE_PAT in the workflows. (And I had to remove them to test this in my fork.)

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Testing

tested in my fork, see 
 - run with no changes: https://github.com/joanise/EveryVoice/actions/runs/12837570859/job/35801524637
 - run with changes: https://github.com/joanise/EveryVoice/actions/runs/12837530499/job/35801398384

### How to test? <!-- Explain how reviewers should test this PR. -->

Make your own forks of the 5 repos, create commits that change the docs or not, and see the docs action push to gh-pages or not.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
