### PR TITLE
feat: adjust the wizard resume message for known compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,6 @@ jobs:
 
   matrix:
     strategy:
-      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
   "merge-args",
   "nltk==3.9.1",
   "numpy<2",                       # torch < 2.4.1 requires numpy < 2 but fails to declare it
+  "packaging>=20.9",
   "pandas~=2.0",
   "panphon==0.20.0",
   "protobuf~=4.25",                # https://github.com/EveryVoiceTTS/EveryVoice/issues/387


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

The warning about the resume file coming from a different version is too generic. We know 0.2.0 and 0.3.0 resume files are compatible, so adjust the warning to pay attention the which versions are compatible and not.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Are the two new messages clearer, and less likely to cause confusion?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

Take an existing save wizard progress file, and edit line 2 to show version 0.3.0 (current), 0.2.0 (older and still compatible) or 0.1.0 (older, not compatible) and see no message, still compat message, or not compat message, respectively.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
