### PR TITLE
feat: add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies and package
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-          pip install -e .[dev] coverage
+          pip install -e .[dev]
       - run: pip freeze
       - run: pip list
       - uses: tj-actions/changed-files@v45
@@ -96,3 +96,27 @@ jobs:
           echo ""
           ! licensecheck --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY \
           || echo "The package(s) listed just above this line is/are potentially a problem."
+
+  matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update
+      - run: sudo apt-get install --fix-missing sox libsox-dev ffmpeg
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install dependencies and package
+        run: |
+          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+          pip install -e .[dev]
+      - run: pip freeze
+      - run: pip list
+      - run: cd everyvoice && coverage run run_tests.py dev

--- a/everyvoice/wizard/utils.py
+++ b/everyvoice/wizard/utils.py
@@ -169,6 +169,9 @@ class EnumDict(UserDict):
     def __delitem__(self, key):
         super().__delitem__(self.convert_key(key))
 
+    def get(self, key, default=None):
+        return super().get(self.convert_key(key), default)
+
 
 class NodeMixinWithNavigation(NodeMixin):
     """A NodeMixin subclass that allows for navigation between siblings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
   { name = "Samuel Larkin", email = "Samuel.Larkin@nrc-cnrc.gc.ca" },
 ]
 readme = "README.md"
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 keywords = ["TTS", "CLI"]
 classifiers = [
   "Intended Audience :: Developers",
@@ -35,6 +35,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation",
   "Programming Language :: Python",
   "Programming Language :: Unix Shell",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Add support for Python 3.12 in EveryVoice

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

UserDict added its own implementation of `get()` in Python 3.12 (see https://github.com/python/cpython/pull/17910/files) and that broke our EnumDict. Fixed by adding our implementation of `get()` in EnumDict too.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity 

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

~I'm going to add matrix testing, to test this.~

Added matrix testing to exercise all the supported Python versions: 3.10 is the main test workflow, and 3.11 and 3.12 in the matrix one, with just unit testing.

### How to test? <!-- Explain how reviewers should test this PR. -->

make a new env with Python 3.12 and play around.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
