### PR TITLE
Fix `--diagnostic` to work with `uv`

### DIFF
--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -106,7 +106,11 @@ class CLITest(TestCase):
         with capture_stdout():
             result = self.runner.invoke(app, ["--diagnostic"])
         self.assertEqual(result.exit_code, 0)
+        self.assertIn("EveryVoice version", result.stdout)
         self.assertIn("Python version", result.stdout)
+        # Check in the dependency list if we can find EveryVoice
+        # Start by removing `--diagnostic`'s header whic doesn't contain dependencies.
+        self.assertIn("everyvoice", "".join(result.stdout.lower().splitlines()[5:]))
 
     def wip_test_synthesize(self):
         # TODO: Here's a stub for getting synthesis unit tests working


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

We moved to `uv` in #643 thus I created a `conda` free shell which fails with `everyvoice --diagnostic`.

### PR Goal? <!-- Explain the main objective of this PR. -->

#643 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->

Code review

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No

### How to test? <!-- Explain how reviewers should test this PR. -->

```sh
everyvoice --diagnostic
```
or
```sh
python -m unittest everyvoice.tests.test_cli.CLITest.test_diagnostic
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

fair

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

None

<!-- Add any other relevant information here -->
