### PR TITLE
feat: bump the default Python version to 3.12 in make-everyvoice-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git submodule update --init
 
 ### Environment and installation – automated
 
-To run EveryVoice, you need to create a new environment using Conda and Python 3.10, install all our dependencies and EveryVoice itself.
+To run EveryVoice, you need to create a new environment using Conda and Python 3.12, install all our dependencies and EveryVoice itself.
 
 We have automated the procedure required to do all this in the script `make-everyvoice-env`, which you can run like this:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ If you prefer to do the complete installation process manually, or if the automa
 ### TL;DR
 
 ```
-conda create --name EveryVoice python=3.10
+conda create --name EveryVoice python=3.12
 conda activate EveryVoice
 conda install sox -c conda-forge
 conda install ffmpeg
@@ -52,9 +52,9 @@ Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](h
 
 ### Create the environment
 
-Use conda to create a new environment based on Python 3.10:
+Use conda to create a new environment based on Python 3.12:
 ```sh
-conda create --name EveryVoice python=3.10
+conda create --name EveryVoice python=3.12
 conda activate EveryVoice
 ```
 
@@ -121,7 +121,7 @@ If you can install sox, libsox-dev and ffmpeg using your OS packages or by other
 you can now install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv, which is much faster to create and activate.
 
 ```
-uv venv -p 3.10 .venv-EveryVoice
+uv venv -p 3.12 .venv-EveryVoice
 source .venv-EveryVoice/bin/activate
 uv pip install torch==2.3.1+cu118 torchaudio==2.3.1+cu118 --find-links https://download.pytorch.org/whl/torch_stable.html
 uv pip install -e .[dev]

--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -5,7 +5,7 @@
 
 # Default versions:
 CUDA_VERSION=11.8
-PYTHON_VERSION=3.10
+PYTHON_VERSION=3.12
 
 usage() {
     cat <<==EOF== >&2


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

We're still building EV envs with Python 3.10 by default, but I don't see any good reasons for that. This PR bumps the default to 3.12.

While it's a tiny change in the code, I want this to have its own PR so merging it (or not) is a deliberate decision.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Your vote on whether you think this bump is a good idea or not.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

CI matrix testing already exercises 3.12, so this is already exercised.

### How to test? <!-- Explain how reviewers should test this PR. -->

You could build a new env with py 3.12 and make sure EV works.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

none

<!-- Add any other relevant information here -->
