### PR TITLE
Clarify the installation instructions conda vs uv via tabbed views

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Read the full [EveryVoice documentation](https://docs.everyvoice.ca/).
 
 In particular, read the [Guides](https://docs.everyvoice.ca/latest/guides/) to get familiar with the whole process.
 
+To build and view the documentation locally:
+```
+pip install -e .[docs]
+mkdocs serve
+```
+and browse to http://127.0.0.1:8000/.
+
 ## Contributing
 
 Feel free to dive in! [Open an issue](https://github.com/EveryVoiceTTS/EveryVoice/issues/new) or submit PRs.

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,13 +2,34 @@
 
 In order to use EveryVoice on GPUs, you must install PyTorch and Cuda, Python 3.10 or more recent, a number of other dependencies, and EveryVoice itself. The following sections describe various ways to accomplish this.
 
+## Choosing your package manager
+
+Before you start, you must choose a package manager.
+
+We recommend using either `conda` or `uv`.
+
+- **conda**: somewhat slow, but highly reliable &mdash; can install all the EveryVoice dependencies,
+    including the non-Python ones. We provide a fully automated script to do it all with conda.
+
+    You can install conda via [miniforge](https://github.com/conda-forge/miniforge) for free (recommended) or,
+    if you have or can get a license, [miniconda](https://docs.conda.io/en/latest/miniconda.html) or
+    [conda](https://docs.conda.io/projects/conda/en/stable/).
+
+- **uv**: much faster, but manages only the Python dependencies.
+
+    If you are able to install sox, libsox-dev and ffmpeg using your OS packages or by other means
+    (see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
+    you might prefer using uv; otherwise, use conda.
+
+    [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
+
 ## Installation from PyPI
 
 Direct installation from PyPI is fairly reliable.
 
- - Follow the instructions in [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file) to install sox, ffmpeg, torch and torchaudio.
+- Follow the instructions in [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file) to install sox, ffmpeg, torch and torchaudio.
 
- - Install EveryVoice:
+- Install EveryVoice:
 
 === "Using conda"
 
@@ -20,6 +41,16 @@ Direct installation from PyPI is fairly reliable.
 
 ## Installation from source
 
+### Clone the repo
+
+You can obtain the source code by cloning the EveryVoice repo and its submodules:
+
+```sh
+git clone https://github.com/EveryVoiceTTS/EveryVoice.git
+cd EveryVoice
+git submodule update --init
+```
+
 ### Scripted installation &mdash; recommended
 
 While the EveryVoice installation process has gotten simpler as the project matures,
@@ -27,150 +58,122 @@ we maintain a script to automate the process and keep it reliable.
 
 === "Using conda"
 
-	- Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
-	- Clone the EveryVoice repo and its submodules:
-		```sh
-		git clone https://github.com/EveryVoiceTTS/EveryVoice.git
-		cd EveryVoice
-		git submodule update --init
-		```
-	- Run our automated environment creation script
-		```sh
-		./make-everyvoice-env --name EveryVoice
-		conda activate EveryVoice
-		```
-		Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
-		or `--cpu` to use Torch compiled for CPU use only.
+    - Run our automated environment creation script:
+        ```sh
+        ./make-everyvoice-env --name EveryVoice
+        conda activate EveryVoice
+        ```
+        Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
+        or `--cpu` to use Torch compiled for CPU use only.
 
 === "Using uv"
 
-	If you can install sox, libsox-dev and ffmpeg using your OS packages or by other means
-	(see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
-	you can install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv; otherwise, use conda.
-
-    - [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
-	- Clone the EveryVoice repo and its submodules:
-		```sh
-		git clone https://github.com/EveryVoiceTTS/EveryVoice.git
-		cd EveryVoice
-		git submodule update --init
-		```
-	- Run our automated environment creation script
-		```sh
-		./make-everyvoice-env --uv
-		source .venv/bin/activate
-		```
-		Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
-	    or `--cpu` to use Torch compiled for CPU use only.
+    - Having installed sox, libsox-dev and ffmpeg (see above), run our automated environment creation script:
+        ```sh
+        ./make-everyvoice-env --uv
+        source .venv/bin/activate
+        ```
+        Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
+        or `--cpu` to use Torch compiled for CPU use only.
 
 ### Manual installation &mdash; TL;DR
 
 === "Using conda"
 
-	```
-	conda create --name EveryVoice python=3.12 ffmpeg
-	conda activate EveryVoice
-	conda install sox -c conda-forge
-	CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-	pip install -e .[dev]
-	```
+    ```
+    conda create --name EveryVoice python=3.12 ffmpeg
+    conda activate EveryVoice
+    conda install sox -c conda-forge
+    CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+    pip install -e .[dev]
+    ```
 
 === "Using uv"
 
-    First install [sox, libsox-dev and ffmpeg](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi) externally.
-
-	```
-	uv venv -p 3.12 .venv
-	source .venv/bin/activate
-	uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
-	uv pip install -e .[dev]
-	```
+    Install sox, libsox-dev and ffmpeg (see above), then run:
+    ```
+    uv venv -p 3.12 .venv
+    source .venv/bin/activate
+    uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
+    uv pip install -e .[dev]
+    ```
 
 ### Manual installation &mdash; Detailed
 
 If you prefer to do the complete installation process manually, or if the
 automated process does not work for you, follow these steps.
 
-#### Install your package manager
-
-=== "Using conda"
-
-	Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
-
-=== "Using uv"
-
-    [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
-
 #### Create the environment
 
+Create a new environment based on Python 3.12 and activate it:
+
 === "Using conda"
 
-	Use conda to create a new environment based on Python 3.12:
-	```sh
-	conda create --name EveryVoice python=3.12
-	conda activate EveryVoice
-	```
+    ```sh
+    conda create --name EveryVoice python=3.12
+    conda activate EveryVoice
+    ```
 
 === "Using uv"
 
-    Use uv to create a new environment based on Python 3.12:
-	```sh
-	uv venv -p 3.12
-	source .venv/bin/activate
-	```
+    ```sh
+    uv venv -p 3.12
+    source .venv/bin/activate
+    ```
 
 #### Pytorch dependencies
 
 === "Using conda"
 
-	Install our pytorch requirements from `requirements.torch.txt`, replacing `cu121` below (for
-	CUDA 12.1) by your actual CUDA version tag (cu118 or higher), or by `cpu` for a CPU-only installation:
+    Install our pytorch requirements from `requirements.torch.txt`:
 
-	```sh
-	CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-	```
+    ```sh
+    CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+    ```
 
 === "Using uv"
 
     Install our pytorch requirements specified in `requirements.torch.txt`, but manually.
-	(Unfortunately, `uv` does not support the environment variable we use with pip and conda.)
-	Replace `cu121` by your actual CUDA version tag, or by `cpu` for a CPU-only installation.
+    (Unfortunately, `uv` does not support the environment variable we use with pip and conda.)
 
-	```sh
-	uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
-	```
+    ```sh
+    uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
+    ```
+
+Replace `cu121` above (for CUDA 12.1) by your actual CUDA version tag (cu118 or
+cu121), or by `cpu` for a CPU-only installation.
 
 Alternatively, you can follow the [PyTorch installation instructions](https://pytorch.org/get-started/locally/) relevant to your hardware.
-Make sure you specify the version declared in `requirements.torch.txt`, which is 2.3.1 at the moment.
+Make sure you specify the version declared in `requirements.torch.txt`, which is 2.3.1 at the moment,
 if you install EveryVoice from GitHub, but 2.1.0 if you install it from PyPI.
 
 #### Non-Python dependencies
 
 === "Using conda"
 
-	Install sox and ffmpeg with conda if you didn't install them using OS packages:
-	```sh
-	conda install sox -c conda-forge
-	conda install ffmpeg
-	```
+    Install sox and ffmpeg with conda if you didn't install them using OS packages:
+    ```sh
+    conda install sox -c conda-forge
+    conda install ffmpeg
+    ```
 
 === "Using uv"
 
     Uv does not provide a mechanism for installing non-Python dependencies.
-	You must follow the sox, libsox-dev and ffmpeg installation instructions in our
-	[README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)
-	if you want to use uv.
+    You must follow the sox, libsox-dev and ffmpeg installation instructions in our
+    [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)
+    if you want to use uv.
 
 #### Handling running out of temp disk space
 
 Installation will require a fair bit of space on `~/.cache` and/or `~/.local`, as well as your `$TMPDIR`
-(`/tmp` by default, if `$TMPDIR` is not set).  If you get the error
+(`/tmp` by default, if `$TMPDIR` is not set). If you get the error
 `OSError: [Errno 28] No space left on device` during installation, you may need
 to do one or more of these operations:
 
- - `export TMPDIR=/path/to/a/large/tmp/space` (or maybe `export TMPDIR=.`)
- - `mkdir /path/to/a/large/filesystem/.cache; ln -s /path/to/a/large/filesystem/.cache ~/.cache`
- - `mkdir /path/to/a/large/filesystem/.local; ln -s /path/to/a/large/filesystem/.local ~/.local`
+- `export TMPDIR=/path/to/a/large/tmp/space` (or maybe `export TMPDIR=.`)
+- `mkdir /path/to/a/large/filesystem/.cache; ln -s /path/to/a/large/filesystem/.cache ~/.cache`
+- `mkdir /path/to/a/large/filesystem/.local; ln -s /path/to/a/large/filesystem/.local ~/.local`
 
 #### Install EveryVoice itself
 
@@ -178,15 +181,15 @@ Install EveryVoice locally from your cloned sandbox:
 
 === "Using conda"
 
-	```sh
-	pip install -e .
-	```
+    ```sh
+    pip install -e .
+    ```
 
 === "Using uv"
 
-	```sh
-	uv pip install -e .
-	```
+    ```sh
+    uv pip install -e .
+    ```
 
 #### Dev dependencies
 
@@ -194,15 +197,15 @@ Before you can run the test suites, you'll also need to install the dev dependen
 
 === "Using conda"
 
-	```sh
-	pip install -e .[dev]
-	```
+    ```sh
+    pip install -e .[dev]
+    ```
 
 === "Using uv"
 
-	```sh
-	uv pip install -e .[dev]
-	```
+    ```sh
+    uv pip install -e .[dev]
+    ```
 
 #### Git hooks
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,7 +46,7 @@ we maintain a script to automate the process and keep it reliable.
 
 	If you can install sox, libsox-dev and ffmpeg using your OS packages or by other means
 	(see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
-	you can install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv.
+	you can install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv; otherwise, use conda.
 
     - [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
 	- Clone the EveryVoice repo and its submodules:
@@ -63,78 +63,146 @@ we maintain a script to automate the process and keep it reliable.
 		Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
 	    or `--cpu` to use Torch compiled for CPU use only.
 
-### Manual installation using Conda
+### Manual installation &mdash; TL;DR
 
-If you prefer to do the complete installation process manually, or if the automated process does not work for you, follow these steps.
+=== "Using conda"
 
-#### TL;DR
+	```
+	conda create --name EveryVoice python=3.12 ffmpeg
+	conda activate EveryVoice
+	conda install sox -c conda-forge
+	CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+	pip install -e .[dev]
+	```
 
-```
-conda create --name EveryVoice python=3.12
-conda activate EveryVoice
-conda install sox -c conda-forge
-conda install ffmpeg
-CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-pip install -e .
-```
+=== "Using uv"
 
-#### Install Conda
+    First install [sox, libsox-dev and ffmpeg](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi) externally.
 
-Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
+	```
+	uv venv -p 3.12 .venv
+	source .venv/bin/activate
+	uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
+	uv pip install -e .[dev]
+	```
+
+### Manual installation &mdash; Detailed
+
+If you prefer to do the complete installation process manually, or if the
+automated process does not work for you, follow these steps.
+
+#### Install your package manager
+
+=== "Using conda"
+
+	Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
+
+=== "Using uv"
+
+    [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 #### Create the environment
 
-Use conda to create a new environment based on Python 3.12:
-```sh
-conda create --name EveryVoice python=3.12
-conda activate EveryVoice
-```
+=== "Using conda"
+
+	Use conda to create a new environment based on Python 3.12:
+	```sh
+	conda create --name EveryVoice python=3.12
+	conda activate EveryVoice
+	```
+
+=== "Using uv"
+
+    Use uv to create a new environment based on Python 3.12:
+	```sh
+	uv venv -p 3.12
+	source .venv/bin/activate
+	```
 
 #### Pytorch dependencies
 
-Install our pytorch requirements from `requirements.torch.txt`, replacing `cu121` below (for
-CUDA 12.1) by your actual CUDA version tag (cu118 or higher), or by `cpu` for a CPU-only installation:
+=== "Using conda"
 
-```sh
-CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-```
+	Install our pytorch requirements from `requirements.torch.txt`, replacing `cu121` below (for
+	CUDA 12.1) by your actual CUDA version tag (cu118 or higher), or by `cpu` for a CPU-only installation:
+
+	```sh
+	CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+	```
+
+=== "Using uv"
+
+    Install our pytorch requirements specified in `requirements.torch.txt`, but manually.
+	(Unfortunately, `uv` does not support the environment variable we use with pip and conda.)
+	Replace `cu121` by your actual CUDA version tag, or by `cpu` for a CPU-only installation.
+
+	```sh
+	uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
+	```
 
 Alternatively, you can follow the [PyTorch installation instructions](https://pytorch.org/get-started/locally/) relevant to your hardware.
-Make sure you specify the version declared in `requirements.torch.txt`, which is 2.3.1 at the moment
+Make sure you specify the version declared in `requirements.torch.txt`, which is 2.3.1 at the moment.
 if you install EveryVoice from GitHub, but 2.1.0 if you install it from PyPI.
 
 #### Non-Python dependencies
 
-Install sox and ffmpeg if you didn't install them using OS packages:
-```sh
-conda install sox -c conda-forge
-conda install ffmpeg
-```
+=== "Using conda"
+
+	Install sox and ffmpeg with conda if you didn't install them using OS packages:
+	```sh
+	conda install sox -c conda-forge
+	conda install ffmpeg
+	```
+
+=== "Using uv"
+
+    Uv does not provide a mechanism for installing non-Python dependencies.
+	You must follow the sox, libsox-dev and ffmpeg installation instructions in our
+	[README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)
+	if you want to use uv.
 
 #### Handling running out of temp disk space
 
-Installation will require a fair bit of space on `~/.cache` and your `$TMPDIR`
+Installation will require a fair bit of space on `~/.cache` and/or `~/.local`, as well as your `$TMPDIR`
 (`/tmp` by default, if `$TMPDIR` is not set).  If you get the error
 `OSError: [Errno 28] No space left on device` during installation, you may need
-to do one or both of these operations:
+to do one or more of these operations:
+
  - `export TMPDIR=/path/to/a/large/tmp/space` (or maybe `export TMPDIR=.`)
  - `mkdir /path/to/a/large/filesystem/.cache; ln -s /path/to/a/large/filesystem/.cache ~/.cache`
+ - `mkdir /path/to/a/large/filesystem/.local; ln -s /path/to/a/large/filesystem/.local ~/.local`
 
 #### Install EveryVoice itself
 
 Install EveryVoice locally from your cloned sandbox:
 
-```sh
-pip install -e .
-```
+=== "Using conda"
+
+	```sh
+	pip install -e .
+	```
+
+=== "Using uv"
+
+	```sh
+	uv pip install -e .
+	```
 
 #### Dev dependencies
 
 Before you can run the test suites, you'll also need to install the dev dependencies:
 
-```sh
-pip install -e .[dev]
-```
+=== "Using conda"
+
+	```sh
+	pip install -e .[dev]
+	```
+
+=== "Using uv"
+
+	```sh
+	uv pip install -e .[dev]
+	```
 
 #### Git hooks
 
@@ -146,18 +214,3 @@ gitlint install-hook
 git submodule foreach 'pre-commit install'
 git submodule foreach 'gitlint install-hook'
 ```
-
-## Installation using `uv`
-
-If you can install sox, libsox-dev and ffmpeg using your OS packages or by other means (see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
-you can now install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv, which is much faster to create and activate.
-
-```
-uv venv -p 3.12 .venv-EveryVoice
-source .venv-EveryVoice/bin/activate
-uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
-uv pip install -e .[dev]
-```
-
-(If needed, change the `+cu121` qualifier on torch\* to your actual version of CUDA, or to `+cpu`.
-See [Pytorch dependencies](#pytorch-dependencies) above.)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,41 +1,73 @@
 # Installation
 
-In order to use EveryVoice on GPUs, you must install PyTorch and Cuda, Python 3.10 or more recent, a number of other dependencies, and EveryVoice itself. The following sections describe three ways to accomplish this:
+In order to use EveryVoice on GPUs, you must install PyTorch and Cuda, Python 3.10 or more recent, a number of other dependencies, and EveryVoice itself. The following sections describe various ways to accomplish this.
 
-## Scripted installation -- recommended
+## Installation from PyPI
 
-While the EveryVoice installation process has gotten simpler as the project matures,
-we maintain a script to automate the process and keep it reliable.
-
- - Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
- - Clone the EveryVoice repo and its submodules:
-    ```sh
-	git clone https://github.com/EveryVoiceTTS/EveryVoice.git
-	cd EveryVoice
-	git submodule update --init
-	```
- - Run our automated environment creation script
-    ```sh
-	./make-everyvoice-env --name EveryVoice
-	conda activate EveryVoice
-	```
-	Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version, or `--cpu` to use Torch compiled for CPU use only.
-
-## Install from PyPI
-
-Direct installation from PyPI has become fairly reliable:
+Direct installation from PyPI is fairly reliable.
 
  - Follow the instructions in [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file) to install sox, ffmpeg, torch and torchaudio.
 
  - Install EveryVoice:
 
-       pip install everyvoice==0.1.0a
+=== "Using conda"
 
-## Manual installation using Conda
+        pip install everyvoice==0.2.0a1
+
+=== "Using uv"
+
+        uv pip install everyvoice==0.2.0a1
+
+## Installation from source
+
+### Scripted installation &mdash; recommended
+
+While the EveryVoice installation process has gotten simpler as the project matures,
+we maintain a script to automate the process and keep it reliable.
+
+=== "Using conda"
+
+	- Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
+	- Clone the EveryVoice repo and its submodules:
+		```sh
+		git clone https://github.com/EveryVoiceTTS/EveryVoice.git
+		cd EveryVoice
+		git submodule update --init
+		```
+	- Run our automated environment creation script
+		```sh
+		./make-everyvoice-env --name EveryVoice
+		conda activate EveryVoice
+		```
+		Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
+		or `--cpu` to use Torch compiled for CPU use only.
+
+=== "Using uv"
+
+	If you can install sox, libsox-dev and ffmpeg using your OS packages or by other means
+	(see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
+	you can install EveryVoice in a [`uv`](https://docs.astral.sh/uv/) venv.
+
+    - [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
+	- Clone the EveryVoice repo and its submodules:
+		```sh
+		git clone https://github.com/EveryVoiceTTS/EveryVoice.git
+		cd EveryVoice
+		git submodule update --init
+		```
+	- Run our automated environment creation script
+		```sh
+		./make-everyvoice-env --uv
+		source .venv/bin/activate
+		```
+		Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
+	    or `--cpu` to use Torch compiled for CPU use only.
+
+### Manual installation using Conda
 
 If you prefer to do the complete installation process manually, or if the automated process does not work for you, follow these steps.
 
-### TL;DR
+#### TL;DR
 
 ```
 conda create --name EveryVoice python=3.12
@@ -46,11 +78,11 @@ CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://downlo
 pip install -e .
 ```
 
-### Install Conda
+#### Install Conda
 
 Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [conda](https://docs.conda.io/projects/conda/en/stable/).
 
-### Create the environment
+#### Create the environment
 
 Use conda to create a new environment based on Python 3.12:
 ```sh
@@ -58,7 +90,7 @@ conda create --name EveryVoice python=3.12
 conda activate EveryVoice
 ```
 
-### Pytorch dependencies
+#### Pytorch dependencies
 
 Install our pytorch requirements from `requirements.torch.txt`, replacing `cu121` below (for
 CUDA 12.1) by your actual CUDA version tag (cu118 or higher), or by `cpu` for a CPU-only installation:
@@ -71,7 +103,7 @@ Alternatively, you can follow the [PyTorch installation instructions](https://py
 Make sure you specify the version declared in `requirements.torch.txt`, which is 2.3.1 at the moment
 if you install EveryVoice from GitHub, but 2.1.0 if you install it from PyPI.
 
-### Non-Python dependencies
+#### Non-Python dependencies
 
 Install sox and ffmpeg if you didn't install them using OS packages:
 ```sh
@@ -79,7 +111,7 @@ conda install sox -c conda-forge
 conda install ffmpeg
 ```
 
-### Handling running out of temp disk space
+#### Handling running out of temp disk space
 
 Installation will require a fair bit of space on `~/.cache` and your `$TMPDIR`
 (`/tmp` by default, if `$TMPDIR` is not set).  If you get the error
@@ -88,7 +120,7 @@ to do one or both of these operations:
  - `export TMPDIR=/path/to/a/large/tmp/space` (or maybe `export TMPDIR=.`)
  - `mkdir /path/to/a/large/filesystem/.cache; ln -s /path/to/a/large/filesystem/.cache ~/.cache`
 
-### Install EveryVoice itself
+#### Install EveryVoice itself
 
 Install EveryVoice locally from your cloned sandbox:
 
@@ -96,7 +128,7 @@ Install EveryVoice locally from your cloned sandbox:
 pip install -e .
 ```
 
-### Dev dependencies
+#### Dev dependencies
 
 Before you can run the test suites, you'll also need to install the dev dependencies:
 
@@ -104,7 +136,7 @@ Before you can run the test suites, you'll also need to install the dev dependen
 pip install -e .[dev]
 ```
 
-### Git hooks
+#### Git hooks
 
 If you plan to contribute to the project, please install our Git hooks:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,23 +11,28 @@ We recommend using either `conda` or `uv`.
 - **conda**: somewhat slow, but highly reliable &mdash; can install all the EveryVoice dependencies,
     including the non-Python ones. We provide a fully automated script to do it all with conda.
 
-    You can install conda via [miniforge](https://github.com/conda-forge/miniforge) for free (recommended) or,
-    if you have or can get a license, [miniconda](https://docs.conda.io/en/latest/miniconda.html) or
-    [conda](https://docs.conda.io/projects/conda/en/stable/).
+    You can install conda via [Miniforge](https://conda-forge.org/download/) for free or,
+    if you have a valid Anaconda license or can get one, [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or
+    [Conda](https://docs.conda.io/projects/conda/en/stable/).
 
-- **uv**: much faster, but manages only the Python dependencies.
+- **uv**: much faster, but manages only the Python dependencies.  [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
 
-    If you are able to install sox, libsox-dev and ffmpeg using your OS packages or by other means
-    (see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
-    you might prefer using uv; otherwise, use conda.
+If you are able to install sox, libsox-dev and ffmpeg using your OS packages or by other means
+(see [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file#quickstart-from-pypi)),
+you might prefer using uv; otherwise, use conda.
 
-    [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
+## Choosing your Python version
+
+EveryVoice supports Python 3.10, 3.11 and 3.12. We use 3.12 everywhere in this
+document, but you can use your preferred version among these instead.
 
 ## Installation from PyPI
 
 Direct installation from PyPI is fairly reliable.
 
 - Follow the instructions in [README.md](https://github.com/EveryVoiceTTS/EveryVoice?tab=readme-ov-file) to install sox, ffmpeg, torch and torchaudio.
+
+- Ideally create a virtual environment for your project.
 
 - Install EveryVoice:
 
@@ -51,7 +56,7 @@ cd EveryVoice
 git submodule update --init
 ```
 
-### Scripted installation &mdash; recommended
+### Option 1 &mdash; Scripted installation &mdash; recommended
 
 While the EveryVoice installation process has gotten simpler as the project matures,
 we maintain a script to automate the process and keep it reliable.
@@ -76,7 +81,7 @@ we maintain a script to automate the process and keep it reliable.
         Add the option `--cuda CUDA_VERSION` if you need to override the default CUDA version,
         or `--cpu` to use Torch compiled for CPU use only.
 
-### Manual installation &mdash; TL;DR
+### Option 2-a &mdash; Manual installation &mdash; Compact summary
 
 === "Using conda"
 
@@ -98,14 +103,14 @@ we maintain a script to automate the process and keep it reliable.
     uv pip install -e .[dev]
     ```
 
-### Manual installation &mdash; Detailed
+### Option 2-b &mdash; Manual installation &mdash; Detailed
 
 If you prefer to do the complete installation process manually, or if the
 automated process does not work for you, follow these steps.
 
 #### Create the environment
 
-Create a new environment based on Python 3.12 and activate it:
+Create a new virtual environment and activate it:
 
 === "Using conda"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ theme:
   features:
     - content.code.copy
     - content.code.select
+    - content.tabs.link
     - announce.dismiss
     - content.footnote.tooltips
     - navigation.instant
@@ -49,6 +50,8 @@ markdown_extensions:
   - pymdownx.superfences
   - toc:
       permalink: true
+  - pymdownx.tabbed:
+      alternate_style: true
 nav:
   - Getting Started: index.md
   - Installation: install.md


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

My earlier attempt at providing uv installation instructions were quite confusing. This PR cleans that up significantly, using a tabbed view where you can click "Using conda" or "Using uv" once, and all the instructions shown are toggled to your chosen package manager.

I also make the uv prerequisites clearer.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

confusing instructions

### Feedback sought? <!-- What should reviewers focus on in particular? -->

How are the new instructions? Are they clear? Can I make them better?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### Preview the changes

https://joanise.github.io/EveryVoice/dev/install/

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high - these are certainly much better than before

but medium - they can surely still be improved

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
