### PR TITLE
Dev.ej/misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In particular, read the [Guides](https://docs.everyvoice.ca/latest/guides/) to g
 
 To build and view the documentation locally:
 ```
-pip install -e .[docs]
+pip install -e '.[docs]'
 mkdocs serve
 ```
 and browse to http://127.0.0.1:8000/.
@@ -82,7 +82,7 @@ This repo follows the [Contributor Covenant](http://contributor-covenant.org/ver
 Please make sure our standard Git hooks are activated, by running these commands in your sandbox (if you used our `make-everyvoice-env` script then this step is already done for you):
 
 ```sh
-pip install -e .[dev]
+pip install -e '.[dev]'
 pre-commit install
 gitlint install-hook
 git submodule foreach 'pre-commit install'

--- a/docs/install.md
+++ b/docs/install.md
@@ -90,7 +90,7 @@ we maintain a script to automate the process and keep it reliable.
     conda activate EveryVoice
     conda install sox -c conda-forge
     CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-    pip install -e .[dev]
+    pip install -e '.[dev]'
     ```
 
 === "Using uv"
@@ -100,7 +100,7 @@ we maintain a script to automate the process and keep it reliable.
     uv venv -p 3.12 .venv
     source .venv/bin/activate
     uv pip install torch==2.3.1+cu121 torchaudio==2.3.1+cu121 --find-links https://download.pytorch.org/whl/torch_stable.html
-    uv pip install -e .[dev]
+    uv pip install -e '.[dev]'
     ```
 
 ### Option 2-b &mdash; Manual installation &mdash; Detailed
@@ -203,13 +203,13 @@ Before you can run the test suites, you'll also need to install the dev dependen
 === "Using conda"
 
     ```sh
-    pip install -e .[dev]
+    pip install -e '.[dev]'
     ```
 
 === "Using uv"
 
     ```sh
-    uv pip install -e .[dev]
+    uv pip install -e '.[dev]'
     ```
 
 #### Git hooks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ repo_url: https://github.com/EveryVoiceTTS/EveryVoice
 repo_name: EveryVoiceTTS/EveryVoice
 theme:
   name: material
-  favicon: favicon-32x32.png
   custom_dir: docs/overrides
   palette:
     # Palette toggle for light mode


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

remove the broken favicon setting

provide install instructions that work on Mac with zsh (the default shell): `pip install -e .[dev]` does not work on zsh, you need to quote it like `pip install -e '.[dev]'`.

