### PR TITLE
build: bump librosa to the latest to fix deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "gradio>=5.9.1",
   "grapheme>=0.6.0",
   "ipatok>=0.4.1",
-  "librosa==0.9.2",
+  "librosa==0.11.0",
   "lightning>=2.0.0",
   "loguru==0.6.0",
   "matplotlib~=3.9.0",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix the warnings we get from our locked version of librosa using deprecated `pkg_resources` features.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #667

### Feedback sought? <!-- What should reviewers focus on in particular? -->

just making sure it doesn't break synthesis

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

this sprint ideally

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

The library already gets exercised through regression. I ran it and it passed, so the software is compatible.

### How to test? <!-- Explain how reviewers should test this PR. -->

librosa creates our mel spectrograms, so any test that goes through training and synthesis will exercize these changes. We want to confirm there are no impacts on audio quality.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
