### PR TITLE
feat: cli rename speaker in checkpoint

### DIFF
--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -15,9 +15,8 @@ from rich.panel import Panel
 
 from everyvoice._version import VERSION
 from everyvoice.base_cli.checkpoint import inspect as inspect_checkpoint
-from everyvoice.base_cli.interfaces import (
-    inference_base_command_interface,
-)
+from everyvoice.base_cli.checkpoint import rename_speaker
+from everyvoice.base_cli.interfaces import inference_base_command_interface
 from everyvoice.model.aligner.wav2vec2aligner.aligner.cli import (
     ALIGN_SINGLE_LONG_HELP,
     ALIGN_SINGLE_SHORT_HELP,
@@ -564,6 +563,11 @@ app.command(
     name="inspect-checkpoint",
     short_help="Extract structural information from a checkpoint",
 )(inspect_checkpoint)
+
+app.command(
+    name="rename-speaker",
+    short_help="Rename a speaker in the checkpoint's parameters",
+)(rename_speaker)
 
 
 TestSuites = Enum("TestSuites", {name: name for name in SUITE_NAMES})  # type: ignore


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->
Adding the ability to change the speaker name in checkpoint


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
Fixes #620


### Feedback sought? <!-- What should reviewers focus on in particular? -->
basic check


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
low


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
Test added


### How to test? <!-- Explain how reviewers should test this PR. -->
from the cli 
`everyvoice inspect-checkpoint`

Get the speaker name

` everyvoice rename-speaker  MODEL_PATH OLD_SPEAKER_NAME  NEW_SPEAKER_NAME`

`everyvoice inspect-checkpoint` 

to see the new speaker name

### Confidence? <!-- How confident are you that these changes are ready to merge? -->
100%


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->



<!-- Add any other relevant information here -->
