### PR TITLE
Upgrade Pytorch 2.7.1

### DIFF
--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -4,7 +4,7 @@
 # manual instructions in README.md
 
 # Default versions:
-CUDA_VERSION=12.1
+CUDA_VERSION=12.6
 PYTHON_VERSION=3.12
 
 usage() {
@@ -23,6 +23,7 @@ Torch pre-compilation options:
                           Default: --cuda $CUDA_VERSION
                           Special value: "--cuda system" compiles torch
                           against what is available on the system.
+                          Available: 11.8 , 12.6 , 12.8
   --cpu                   Install torch for use on CPU only
   --python PYTHON_VERSION Specify the Python version to use
                           Default: --python $PYTHON_VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ dependencies = [
   "simple-term-menu==1.5.2",
   "tabulate==0.9.0",
   "tensorboard>=2.14.1",
-  "torch==2.3.1",
-  "torchaudio==2.3.1",
+  "torch==2.7.1",
+  "torchaudio==2.7.1",
   "torchinfo==1.8.0",
   "tqdm>=4.66.0",
   "typer>=0.15.3",
@@ -88,8 +88,8 @@ dynamic = ["version"]
 torch = [
   # these requirements have to be installed ahead of time in your environment and from a different URL:
   # CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-  'torch==2.3.1; sys_platform == "darwin"',
-  'torchaudio==2.3.1; sys_platform == "darwin"',
+  'torch==2.7.1; sys_platform == "darwin"',
+  'torchaudio==2.7.1; sys_platform == "darwin"',
 ]
 dev = [
   "black~=24.3",

--- a/requirements.torch.txt
+++ b/requirements.torch.txt
@@ -1,6 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 # these requirements have to be installed ahead of time in your environment and from a different URL:
 # CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.3.1; sys_platform == "darwin"
-torchaudio==2.3.1; sys_platform == "darwin"
-torch==2.3.1+${CUDA_TAG}; sys_platform != "darwin"
-torchaudio==2.3.1+${CUDA_TAG}; sys_platform != "darwin"
+torch==2.7.1; sys_platform == "darwin"
+torchaudio==2.7.1; sys_platform == "darwin"
+torch==2.7.1+${CUDA_TAG}; sys_platform != "darwin"
+torchaudio==2.7.1+${CUDA_TAG}; sys_platform != "darwin"


### PR DESCRIPTION


### PR Goal?
Upgrade  to a version of torch that does not have any known vulnerabilities.
 
Dependabot alert are detecting  that torch  2.3.1  ( <= 2.5.1 )  has this below. Once deployed, we should no loger be getting those  message:

CVE-2025-32434 Critical severity
CVE-2025-2953 Low severity

We had the choice between 2.6.0 or 2.7.1  I decided to go with 2.71 , the current "stable" build.


### Fixes? 
#656

### Feedback sought? 
I tested multiple combinations using UV and conda. 

Default using cuda 12.6
cuda 11.8 and also 12.8 are currently available supported options


### Priority? 
high  enough because of vulnerabilities. It's never fun knowing that some are detected. 

### How to test? 
Do a full new install  using the method of your choice
ex:  `./make-everyvoice-env --conda -n EV_testing_torch271`


### Confidence?  
High

I ran many test using Linux and Mac using various ways ( conda / uv / cuda 118, 126,128  , cpu etc...) 
I also ran a few training runs with success and I did not notice  any quality differences . ( FP / vocoder etc) 


