### PR TITLE
Dev.ej/custom g2p wiz

### DIFF
--- a/everyvoice/tests/g2p_engines/__init__.py
+++ b/everyvoice/tests/g2p_engines/__init__.py
@@ -8,6 +8,13 @@ def valid(a: str) -> List[str]:
     return a.split()
 
 
+def g2p_test_upper(a: str) -> List[str]:
+    """
+    A valid G2P engine with very visible effects, for unit testing
+    """
+    return a.upper().split()
+
+
 def multiple_arguments(a: int, b: int) -> List[str]:
     """
     A G2P engine with the wrong function's signature.

--- a/everyvoice/tests/stubs.py
+++ b/everyvoice/tests/stubs.py
@@ -26,6 +26,9 @@ class monkeypatch:
         self.name = name
         self.value = value
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(obj={self.obj}, name={self.name}, value={self.value})"
+
     def __enter__(self):
         self.saved_value = getattr(self.obj, self.name, self._NOTSET)
         setattr(self.obj, self.name, self.value)
@@ -164,6 +167,10 @@ class patch_menu_prompt:
         self.response_index = response_index
         self.multi = multi
 
+    def __repr__(self):
+        multi = f", multi={self.multi}" if self.multi else ""
+        return f"{self.__class__.__name__}(response_index={self.response_index}{multi})"
+
     def __enter__(self):
         self.monkey1 = monkeypatch(
             prompts,
@@ -188,6 +195,10 @@ class patch_input:
     def __init__(self, response: Any, multi=False):
         self.response = response
         self.multi = multi
+
+    def __repr__(self):
+        multi = f", multi={self.multi}" if self.multi else ""
+        return f"{self.__class__.__name__}(response={self.response}{multi})"
 
     def __enter__(self):
         self.monkey = monkeypatch(builtins, "input", Say(self.response, self.multi))
@@ -215,6 +226,10 @@ class Say:
         self.response = response
         self.last_index = -1
         self.multi = multi
+
+    def __repr__(self):
+        multi = f", multi={self.multi}" if self.multi else ""
+        return f"{self.__class__.__name__}(response={self.response}{multi})"
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         if self.multi:
@@ -309,6 +324,9 @@ class patch_questionary:
     def __init__(self, responses: Path | str | Sequence, ask_ok: bool = False):
         self.responses = responses
         self.ask_ok = ask_ok
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(responses={self.responses}, ask_ok={self.ask_ok})"
 
     def __enter__(self):
         stub = QuestionaryStub(self.responses, self.ask_ok)

--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -688,6 +688,7 @@ class WizardTest(TestCase):
         custom_g2p_step = find_step(SN.custom_g2p_step, tour.steps)
         with monkeypatch(custom_g2p_step, "prompt", Say(0)):
             custom_g2p_step.run()
+        self.assertEqual(custom_g2p_step.language_codes, ["fin"])
 
         wavs_dir_step = find_step(SN.wavs_dir_step, tour.steps)
         with monkeypatch(wavs_dir_step, "prompt", Say(str(self.data_dir))):
@@ -924,7 +925,11 @@ class WizardTest(TestCase):
                     print(repr(step_and_answer.monkey), file=sys.stderr)
                     with step_and_answer.monkey:
                         step.run()
-                    self.assertEqual(state, step.state)
+                    self.assertEqual(
+                        state,
+                        step.state,
+                        f"Undo did not undo correctly for {step.name}",
+                    )
 
                 if step.children and step_and_answer.children_answers:
                     # Here we assemble steps_and_answers for the recursive call from
@@ -1819,6 +1824,169 @@ class WizardTest(TestCase):
                 text_to_spec_config = "\n".join(f)
             self.assertIn("multilingual: false", text_to_spec_config)
             self.assertIn("multispeaker: false", text_to_spec_config)
+
+    def test_custom_g2p(self):
+        """Test using a custom g2p on a custom language code"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            with open(tmpdir / "filelist1.psv", "w", encoding="utf8") as f:
+                f.write(
+                    "\n".join(
+                        [
+                            "basename|text",
+                            "f1|foo bar",
+                            "f2|bar baz",
+                            "f3|baz foo",
+                        ]
+                    )
+                )
+            with open(tmpdir / "filelist2.psv", "w", encoding="utf8") as f:
+                f.write(
+                    "\n".join(
+                        [
+                            "basename|language|text",
+                            "f4|str|foo foo",
+                            "f5|git|bar bar",
+                            "f6|und|baz baz",
+                            "f7|unknown-lang|zang",
+                        ]
+                    )
+                )
+            for i in range(1, 8):
+                with open(tmpdir / f"f{i}.wav", "wb"):
+                    pass
+            more_dataset_children_answers = [
+                RecursiveAnswers(
+                    patch_questionary(tmpdir / "filelist2.psv")
+                ),  # filelist step
+                RecursiveAnswers(
+                    patch_menu_prompt(1),  # yes to permission
+                    children_answers=[
+                        RecursiveAnswers(patch_menu_prompt(0)),  # psv format
+                        RecursiveAnswers(patch_menu_prompt(0)),  # characters
+                        RecursiveAnswers(patch_menu_prompt(())),  # no text prepro
+                        RecursiveAnswers(
+                            patch_menu_prompt(0),  # no, does not have speaker column
+                            children_answers=[
+                                RecursiveAnswers(
+                                    patch_menu_prompt(1),  # Yes, give speaker ID
+                                    children_answers=[
+                                        RecursiveAnswers(patch_input("my_speaker"))
+                                    ],
+                                ),
+                            ],
+                        ),
+                        RecursiveAnswers(
+                            patch_menu_prompt(1),  # yes, there is a language column
+                            children_answers=[
+                                RecursiveAnswers(Say(1))  # speaker column is is 1
+                            ],
+                        ),
+                        RecursiveAnswers(patch_menu_prompt(0)),  # Keep g2p settings
+                        RecursiveAnswers(patch_questionary(tmpdir)),  # wav directory
+                        RecursiveAnswers(null_patch()),  # ValidateWavsStep
+                        RecursiveAnswers(null_patch()),  # SymbolSetStep
+                        RecursiveAnswers(patch_menu_prompt([])),  # no Sox
+                        RecursiveAnswers(patch_input("dataset1")),  # Dataset name
+                    ],
+                ),
+                RecursiveAnswers(
+                    patch_menu_prompt(0),  # no more data
+                    children_answers=[RecursiveAnswers(patch_menu_prompt(0))],  # yaml
+                ),
+            ]
+            steps_and_answers = [
+                StepAndAnswer(basic.NameStep(), patch_input("project")),
+                StepAndAnswer(basic.ContactNameStep(), patch_input("Test Name")),
+                StepAndAnswer(
+                    basic.ContactEmailStep(), patch_input("info@everyvoice.ca")
+                ),
+                StepAndAnswer(
+                    basic.OutputPathStep(), patch_questionary(tmpdir / "out")
+                ),
+                # First dataset
+                StepAndAnswer(
+                    dataset.FilelistStep(state_subset="dataset_0"),
+                    patch_questionary(tmpdir / "filelist1.psv"),
+                ),
+                StepAndAnswer(
+                    dataset.FilelistFormatStep(state_subset="dataset_0"),
+                    patch_menu_prompt(0),  # psv
+                ),
+                StepAndAnswer(
+                    dataset.FilelistTextRepresentationStep(state_subset="dataset_0"),
+                    patch_menu_prompt(0),  # characters
+                ),
+                StepAndAnswer(
+                    dataset.TextProcessingStep(state_subset="dataset_0"),
+                    patch_menu_prompt(()),
+                ),
+                StepAndAnswer(
+                    dataset.HasSpeakerStep(state_subset="dataset_0"),
+                    patch_menu_prompt(0),  # 0 is no
+                    children_answers=[
+                        RecursiveAnswers(patch_menu_prompt(0)),  # 0 is no
+                    ],
+                ),
+                StepAndAnswer(
+                    dataset.HasLanguageStep(state_subset="dataset_0"),
+                    patch_menu_prompt(0),  # 0 is no
+                    children_answers=[RecursiveAnswers(Say("git"))],
+                ),
+                StepAndAnswer(
+                    dataset.CustomG2PStep(state_subset="dataset_0"),
+                    patch_menu_prompt(1),  # custom g2p for "git"
+                    children_answers=[
+                        # RecursiveAnswers(Say("everyvoice.tests.g2p_engines.valid"))
+                        RecursiveAnswers(
+                            patch_input(
+                                (
+                                    "asdf",
+                                    "everyvoice.tests.g2p_engines.not_a_list",
+                                    "everyvoice.tests.g2p_engines.valid",
+                                ),
+                                multi=True,
+                            )
+                        )
+                    ],
+                ),
+                StepAndAnswer(
+                    dataset.WavsDirStep(state_subset="dataset_0"),
+                    patch_questionary(tmpdir),
+                ),
+                StepAndAnswer(
+                    dataset.SymbolSetStep(state_subset="dataset_0"),
+                    null_patch(),
+                ),
+                StepAndAnswer(
+                    dataset.SoxEffectsStep(state_subset="dataset_0"),
+                    patch_menu_prompt([]),
+                ),
+                StepAndAnswer(
+                    dataset.DatasetNameStep(state_subset="dataset_0"),
+                    patch_input("dataset0"),
+                ),
+                StepAndAnswer(
+                    basic.MoreDatasetsStep(),
+                    patch_menu_prompt(1),  # 1 is yes
+                    children_answers=more_dataset_children_answers,
+                ),
+            ]
+            tour, _ = self.monkey_run_tour(
+                "Tour with datafile in the festival format",
+                steps_and_answers,
+                debug=True,
+            )
+
+            with open(
+                tmpdir / "out/project/config/everyvoice-shared-text.yaml",
+                encoding="utf8",
+            ) as f:
+                text_config = "".join(f)
+            self.assertIn(
+                "g2p_engines: {git: everyvoice.tests.g2p_engines.valid}", text_config
+            )
+            # print(text_config)
 
     trivial_tour_results = {
         SN.name_step.value: "project_name",

--- a/everyvoice/utils/__init__.py
+++ b/everyvoice/utils/__init__.py
@@ -248,7 +248,7 @@ def read_festival(
     path,
     record_limit: int = 0,  # if non-zero, read only this many records
     text_field_name: str = "text",
-):
+) -> list[dict[str, str]]:
     """Read Festival format into filelist
     Args:
         path (Path): Path to festival format filelist

--- a/everyvoice/wizard/__init__.py
+++ b/everyvoice/wizard/__init__.py
@@ -36,6 +36,7 @@ class StepNames(Enum):
     custom_g2p_step = "Custom G2P Step"
     select_g2p_engine_step = "Select G2P Engine Step"
     select_language_step = "Select Language Step"
+    language_code_step = "Language Code Step"
     text_processing_step = "Text Processing Step"
     g2p_step = "G2P Step"
     symbol_set_step = "Symbol-Set Step"

--- a/everyvoice/wizard/__init__.py
+++ b/everyvoice/wizard/__init__.py
@@ -33,6 +33,8 @@ class StepNames(Enum):
     add_speaker_step = "Add Speaker Step"
     data_has_language_value_step = "Data Has Language Step"
     language_header_step = "Language Header Step"
+    custom_g2p_step = "Custom G2P Step"
+    select_g2p_engine_step = "Select G2P Engine Step"
     select_language_step = "Select Language Step"
     text_processing_step = "Text Processing Step"
     g2p_step = "G2P Step"

--- a/everyvoice/wizard/basic.py
+++ b/everyvoice/wizard/basic.py
@@ -306,7 +306,10 @@ class ConfigFormatStep(Step):
                 )
             )
 
-        text_config = TextConfig(symbols=Symbols(**symbols))
+        text_config = TextConfig(
+            symbols=Symbols(**symbols),
+            g2p_engines=self.state.get("custom_g2p", {}),
+        )
         text_config.cleaners += global_cleaners
         text_config_path = Path(f"{TEXT_CONFIG_FILENAME_PREFIX}.{self.response}")
         write_dict_to_config(

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -777,7 +777,7 @@ class CustomG2PStep(Step):
                 set_a_custom = "Change the custom"
                 try:
                     current = current.__module__ + "." + current.__name__
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     print(e)
                     current = "unknown"
             self.current_engines.append(current)

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -888,9 +888,9 @@ class SelectG2PEngineStep(Step):
     def effect(self):
         from everyvoice.text.phonemizer import AVAILABLE_G2P_ENGINES
 
-        self.saved_state = {"custom_g2p": deepcopy(self.tour.state.get("custom_g2p"))}
-
+        self.saved_custom_g2p = deepcopy(self.tour.state.get("custom_g2p"))
         self.saved_g2p_func = AVAILABLE_G2P_ENGINES.get(self.language_code, None)
+
         AVAILABLE_G2P_ENGINES[self.language_code] = self.g2p_func
         if "custom_g2p" not in self.tour.state:
             self.tour.state["custom_g2p"] = {}
@@ -904,11 +904,18 @@ class SelectG2PEngineStep(Step):
     def undo(self):
         from everyvoice.text.phonemizer import AVAILABLE_G2P_ENGINES
 
+        match self.saved_custom_g2p:
+            case None:
+                del self.tour.state["custom_g2p"]
+            case _:
+                self.tour.state["custome_g2p"] = self.saved_custom_g2p
+
         match self.saved_g2p_func:
             case None:
                 del AVAILABLE_G2P_ENGINES[self.language_code]
             case _:
                 AVAILABLE_G2P_ENGINES[self.language_code] = self.saved_g2p_func
+
         super().undo()
 
 

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -859,11 +859,13 @@ class SelectG2PEngineStep(Step):
             lang_desc = f"{self.language_name} ({self.language_code})"
         rich_print(
             Panel(
-                f"Please enter the fully qualified Python name of your custom g2p function for {lang_desc}.\n"
-                "E.g., for function my_g2p_map() in mymodule/submodule/g2p_mappings.py, "
-                'answer "mymodule.submodule.g2p_mappings.my_g2p_map".\n'
+                f"Please [bold]enter[/bold] the fully qualified Python name of your custom g2p function for {lang_desc}.\n"
+                "[yellow]Note: you cannot provide a file path to a script. Your g2p function must be installed and accessible as a module in your Python environment,[/yellow] "
+                "e.g., for function my_g2p_map() in mymodule/submodule/g2p_mappings.py, "
+                'install mymodule using pip and answer "mymodule.submodule.g2p_mappings.my_g2p_map".\n'
                 f"[yellow]Warning: custom g2p settings will apply to all '{self.language_code}' data in this project, not just in the current dataset.[/yellow]\n"
-                f"Use Ctrl-C / Go back one step to keep the current settings: {self.current_engine}"
+                f"Current settings: {self.current_engine}\n"
+                'Use Ctrl-C / "Go back one step" to keep the current settings.'
             )
         )
         return input(f"g2p function for {self.language_code}: ")
@@ -880,7 +882,7 @@ class SelectG2PEngineStep(Step):
         except Exception as e:
             rich_print(
                 Panel(
-                    f"Sorry, the function {response} did not pass validation: [red]{e}[/red]"
+                    f"Sorry, the function '{response}' did not pass validation: [red]{e}[/red]"
                 )
             )
             return False

--- a/everyvoice/wizard/tour.py
+++ b/everyvoice/wizard/tour.py
@@ -321,7 +321,7 @@ class Tour:
         # for new questions if possible, or else giving a warning explaining what needs
         # to be changed if auto upgrade is not possible.
         # Regression testing should warn us when such auto-upgrade code is required here.
-        compatible_since = Version("0.2.0a0")
+        compatible_since = Version("0.4.1")
         if version != VERSION:
             if Version(version) >= Version(VERSION):
                 rich_print(

--- a/everyvoice/wizard/tour.py
+++ b/everyvoice/wizard/tour.py
@@ -321,7 +321,7 @@ class Tour:
         # for new questions if possible, or else giving a warning explaining what needs
         # to be changed if auto upgrade is not possible.
         # Regression testing should warn us when such auto-upgrade code is required here.
-        compatible_since = Version("0.4.1")
+        compatible_since = Version("0.4.0.dev0")
         if version != VERSION:
             if Version(version) >= Version(VERSION):
                 rich_print(

--- a/everyvoice/wizard/utils.py
+++ b/everyvoice/wizard/utils.py
@@ -29,16 +29,13 @@ def rename_unknown_headers(headers):
     return headers
 
 
-def apply_automatic_text_conversions(
-    filelist_data, text_representation, global_isocode=None
-) -> str:
+def apply_automatic_text_conversions(filelist_data, text_representation) -> str:
     """Arpabet is automatically converted to phones. phones are automatically derived from characters
        if a corresponding g2p module is available.
 
     Args:
         filelist_data (list[dict]): _description_
         text_representation (DatasetTextRepresentation): _description_
-        isocode (str, optional): _description_. Defaults to None.
     Returns:
         target_training_representation (str): the target training representation level. returns 'phones' unless there is more data available from using 'characters'.
     """
@@ -53,13 +50,7 @@ def apply_automatic_text_conversions(
     character_counter = 0
     phone_counter = 0
     for item in tqdm(filelist_data, desc=f"Processing your {text_representation}"):
-        # add globally defined language code
-        if global_isocode is not None:
-            item["language"] = global_isocode
-            item_isocode = global_isocode
-        else:
-            # define the isocode from the item
-            item_isocode = item.get("language", None)
+        item_isocode = item.get("language", None)
         # convert arpabet to phones
         if (
             DatasetTextRepresentation.arpabet.value in item


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This is my second big PR related to custom g2p in the wizard: this one adds the questions and handles it all, plus testing.

Known bug: if you have a given lang that is used in more than one dataset in the same project, and you set the custom g2p on any other than the first where that language occurs, the earlier datasets won't have been processed with the custom g2p.
I am deferring fixing this issue to its own PR as it entails another significant round of refactoring that I want to do later and have reviewed separately.
Fixing that bug should require no user-visible changes, so the wizard enhancements can be tested and reviewed before that gets fixed.

### Out of scope

 - fixing the bug described above -- ticket created: #712
 - documentation, that's for #354 
 - I might want to handle an old resume files automatically, since the adjustments to run through the current wizard from an old resume file are deterministic. But if I do that, it will be in a separate PR.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #645

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Here I am hoping for good testing, making sure the wizard works well in various scenarios and doesn't break. @marctessier ?

Is the series of questions intuitive or at least easy enough to use?

And @roedoejet I'm hoping for a good code review, it's quite involved.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yup, lots, with high coverage.

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the wizard and play with the custom g2p questions, for datasets with and without a language column, with a custom code or not, and using your own g2p or not.

You can use https://github.com/EveryVoiceTTS/everyvoice_g2p_template_plugin to get ideas on creating more custom g2p functions, but in testing I have been using `everyvoice.tests.g2p_engines.valid` every time I wanted to set a custom one.

Entering bad functions on that custom g2p engine question is also a good thing to test, all problems you can imagine should give a friendly error: module does not exist, function does not exist, wrong signature, and who knows what else.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

decent

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

Yes. We need to at least bump the patch since the wizard becomes incompatible with previous instances if resume files.

But this does not affect the schemas, so bumping the patch is enough.

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

Builds on top of #710

<!-- Add any other relevant information here -->
