### PR TITLE
Change torch from 2.7.1 -> 2.8.0 , cuda default 12.8 ( dependabot #25)

### DIFF
--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -4,7 +4,7 @@
 # manual instructions in README.md
 
 # Default versions:
-CUDA_VERSION=12.6
+CUDA_VERSION=12.8
 PYTHON_VERSION=3.12
 
 usage() {
@@ -23,7 +23,7 @@ Torch pre-compilation options:
                           Default: --cuda $CUDA_VERSION
                           Special value: "--cuda system" compiles torch
                           against what is available on the system.
-                          Available: 11.8 , 12.6 , 12.8
+                          Available: 12.6 , 12.8 , 12.9
   --cpu                   Install torch for use on CPU only
   --python PYTHON_VERSION Specify the Python version to use
                           Default: --python $PYTHON_VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ dependencies = [
   "simple-term-menu==1.5.2",
   "tabulate==0.9.0",
   "tensorboard>=2.14.1",
-  "torch==2.7.1",
-  "torchaudio==2.7.1",
+  "torch==2.8.0",
+  "torchaudio==2.8.0",
   "torchinfo==1.8.0",
   "tqdm>=4.66.0",
   "typer>=0.15.3",
@@ -88,8 +88,8 @@ dynamic = ["version"]
 torch = [
   # these requirements have to be installed ahead of time in your environment and from a different URL:
   # CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-  'torch==2.7.1; sys_platform == "darwin"',
-  'torchaudio==2.7.1; sys_platform == "darwin"',
+  'torch==2.8.0; sys_platform == "darwin"',
+  'torchaudio==2.8.0; sys_platform == "darwin"',
 ]
 dev = [
   "black~=24.3",

--- a/requirements.torch.txt
+++ b/requirements.torch.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG}
 # these requirements have to be installed ahead of time in your environment and from a different URL:
-# CUDA_TAG=cu121 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.7.1; sys_platform == "darwin"
-torchaudio==2.7.1; sys_platform == "darwin"
-torch==2.7.1+${CUDA_TAG}; sys_platform != "darwin"
-torchaudio==2.7.1+${CUDA_TAG}; sys_platform != "darwin"
+# CUDA_TAG=cu128 pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+torch==2.8.0; sys_platform == "darwin"
+torchaudio==2.8.0; sys_platform == "darwin"
+torch==2.8.0+${CUDA_TAG}; sys_platform != "darwin"
+torchaudio==2.8.0+${CUDA_TAG}; sys_platform != "darwin"


### PR DESCRIPTION
Upgrade to the latest version of torch. We are currently using 2.7.1 and being nagged by Dependabot saying that it is not secure. 

PLEASE see the notes below about 2.8.0  and the example warning we are getting in the logs.

### PR Goal? <!-- Explain the main objective of this PR. -->

To not be flagged by Dependabot that the code is insecure.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

https://github.com/EveryVoiceTTS/EveryVoice/issues/734

https://github.com/EveryVoiceTTS/EveryVoice/security/dependabot/25

### Feedback sought? <!-- What should reviewers focus on in particular? -->

I ran the install on Mac, Linux , uv / conda using 12.6 , 12.8 & 12.9 with success.

WARNING! We now get these  messages in the PREPROCESS logs:
ex:
```
warnings.warn(
/gpfs/fs5/nrc/nrc-fs1/ict/others/u/tes001/miniforge3/envs/EveryVoice_2025-08-20_pt2.8.0/lib/python3.12/site-packages/torchaudio/_backend/ffmpeg.py:88: UserWarning: torio.io._streaming_media_decoder.StreamingMediaDecoder has been deprecated. This deprecation is part of a large refactoring effort to transition TorchAudio into a maintenance phase. The decoding and encoding capabilities of PyTorch for both audio and video are being consolidated into TorchCodec. Please see https://github.com/pytorch/audio/issues/3902 for more information. It will be removed from the 2.9 release. 
  s = torchaudio.io.StreamReader(src, format, None, buffer_size)
/gpfs/fs5/nrc/nrc-fs1/ict/others/u/tes001/miniforge3/envs/EveryVoice_2025-08-20_pt2.8.0/lib/python3.12/site-packages/torchaudio/_backend/utils.py:213: UserWarning: In 2.9, this function's implementation will be changed to use torchaudio.load_with_torchcodec` under the hood. Some parameters like ``normalize``, ``format``, ``buffer_size``, and ``backend`` will be ignored. We recommend that you port your code to rely directly on TorchCodec's decoder instead: https://docs.pytorch.org/torchcodec/stable/generated/torchcodec.decoders.AudioDecoder.html#torchcodec.decoders.AudioDecoder.
```

or

```
warnings.warn(
/gpfs/fs5/nrc/nrc-fs1/ict/others/u/tes001/miniforge3/envs/EveryVoice_2025-08-20_pt2.8.0/lib/python3.12/site-packages/torchaudio/_backend/ffmpeg.py:247: UserWarning: torio.io._streaming_media_encoder.St
reamingMediaEncoder has been deprecated. This deprecation is part of a large refactoring effort to transition TorchAudio into a maintenance phase. The decoding and encoding capabilities of PyTorch for 
both audio and video are being consolidated into TorchCodec. Please see https://github.com/pytorch/audio/issues/3902 for more information. It will be removed from the 2.9 release. 
 s = torchaudio.io.StreamWriter(uri, format=muxer, buffer_size=buffer_size)
```

Those warning  messages will get repeated multiple time during preprocessing. 

!!!!!!--->  see https://github.com/pytorch/audio/issues/3902   ( _Starting with TorchAudio 2.8 (expected around August 2025), APIs slated for removal will trigger a deprecation warning. These APIs will be fully removed in TorchAudio 2.9 (anticipated by the end of 2025)_.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

soon ...

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

none

### How to test? <!-- Explain how reviewers should test this PR. -->

Install EV. can you preprocess? can you train? 

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.  I did not  noticed any difference yet.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

not now...

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->



<!-- Add any other relevant information here -->
