### PR TITLE
fix: use questionary.text in Wizard

### DIFF
--- a/everyvoice/tests/stubs.py
+++ b/everyvoice/tests/stubs.py
@@ -1,4 +1,3 @@
-import builtins
 import io
 import logging
 import os
@@ -185,27 +184,6 @@ class patch_menu_prompt:
     def __exit__(self, *_exc_info):
         self.monkey2.__exit__(*_exc_info)
         self.monkey1.__exit__(*_exc_info)
-
-
-class patch_input:
-    """Shortcut for patching the builtin input() function, which we need often.
-
-    Args: see class Say"""
-
-    def __init__(self, response: Any, multi=False):
-        self.response = response
-        self.multi = multi
-
-    def __repr__(self):
-        multi = f", multi={self.multi}" if self.multi else ""
-        return f"{self.__class__.__name__}(response={self.response}{multi})"
-
-    def __enter__(self):
-        self.monkey = monkeypatch(builtins, "input", Say(self.response, self.multi))
-        return self.monkey.__enter__()
-
-    def __exit__(self, *_exc_info):
-        self.monkey.__exit__(*_exc_info)
 
 
 class null_patch:

--- a/everyvoice/tests/test_custom_g2p.py
+++ b/everyvoice/tests/test_custom_g2p.py
@@ -13,7 +13,6 @@ from everyvoice.tests.stubs import (
     Say,
     mute_logger,
     null_patch,
-    patch_input,
     patch_logger,
     patch_menu_prompt,
     patch_questionary,
@@ -336,7 +335,9 @@ class CustomG2pTest(WizardTestBase):
                                 RecursiveAnswers(
                                     patch_menu_prompt(1),  # Yes, give speaker ID
                                     children_answers=[
-                                        RecursiveAnswers(patch_input("my_speaker"))
+                                        RecursiveAnswers(
+                                            patch_questionary("my_speaker")
+                                        )
                                     ],
                                 ),
                             ],
@@ -348,9 +349,9 @@ class CustomG2pTest(WizardTestBase):
                                     patch_menu_prompt(1),  # [custom] lang code option
                                     children_answers=[
                                         RecursiveAnswers(
-                                            patch_input(
+                                            patch_questionary(
                                                 ["not valid / bad slug", "my-lang"],
-                                                multi=True,
+                                                True,
                                             )
                                         )
                                     ],
@@ -363,7 +364,7 @@ class CustomG2pTest(WizardTestBase):
                         RecursiveAnswers(null_patch()),  # ValidateWavsStep
                         RecursiveAnswers(null_patch()),  # SymbolSetStep
                         RecursiveAnswers(patch_menu_prompt([])),  # no Sox
-                        RecursiveAnswers(patch_input("dataset2")),  # Dataset name
+                        RecursiveAnswers(patch_questionary("dataset2")),  # Dataset name
                     ],
                 ),
                 RecursiveAnswers(
@@ -387,7 +388,9 @@ class CustomG2pTest(WizardTestBase):
                                 RecursiveAnswers(
                                     patch_menu_prompt(1),  # Yes, give speaker ID
                                     children_answers=[
-                                        RecursiveAnswers(patch_input("my_speaker"))
+                                        RecursiveAnswers(
+                                            patch_questionary("my_speaker")
+                                        )
                                     ],
                                 ),
                             ],
@@ -402,7 +405,9 @@ class CustomG2pTest(WizardTestBase):
                             patch_menu_prompt(2),  # custom g2p for "lang1"
                             children_answers=[
                                 RecursiveAnswers(
-                                    patch_input("everyvoice.tests.g2p_engines.valid")
+                                    patch_questionary(
+                                        "everyvoice.tests.g2p_engines.valid"
+                                    )
                                 ),
                                 RecursiveAnswers(
                                     patch_menu_prompt(0),  # done with custom g2p
@@ -413,7 +418,7 @@ class CustomG2pTest(WizardTestBase):
                         RecursiveAnswers(null_patch()),  # ValidateWavsStep
                         RecursiveAnswers(null_patch()),  # SymbolSetStep
                         RecursiveAnswers(patch_menu_prompt([])),  # no Sox
-                        RecursiveAnswers(patch_input("dataset1")),  # Dataset name
+                        RecursiveAnswers(patch_questionary("dataset1")),  # Dataset name
                     ],
                 ),
                 RecursiveAnswers(
@@ -422,10 +427,10 @@ class CustomG2pTest(WizardTestBase):
                 ),
             ]
             steps_and_answers = [
-                StepAndAnswer(basic.NameStep(), patch_input("project")),
-                StepAndAnswer(basic.ContactNameStep(), patch_input("Test Name")),
+                StepAndAnswer(basic.NameStep(), patch_questionary("project")),
+                StepAndAnswer(basic.ContactNameStep(), patch_questionary("Test Name")),
                 StepAndAnswer(
-                    basic.ContactEmailStep(), patch_input("info@everyvoice.ca")
+                    basic.ContactEmailStep(), patch_questionary("info@everyvoice.ca")
                 ),
                 StepAndAnswer(
                     basic.OutputPathStep(), patch_questionary(tmpdir / "out")
@@ -465,13 +470,13 @@ class CustomG2pTest(WizardTestBase):
                     children_answers=[
                         # RecursiveAnswers(Say("everyvoice.tests.g2p_engines.valid"))
                         RecursiveAnswers(
-                            patch_input(
+                            patch_questionary(
                                 (
                                     "asdf",
                                     "everyvoice.tests.g2p_engines.not_a_list",
                                     "everyvoice.tests.g2p_engines.g2p_test_upper",
                                 ),
-                                multi=True,
+                                True,
                             )
                         ),
                         RecursiveAnswers(patch_menu_prompt(0)),  # keep g2p
@@ -491,7 +496,7 @@ class CustomG2pTest(WizardTestBase):
                 ),
                 StepAndAnswer(
                     dataset.DatasetNameStep(state_subset="dataset_0"),
-                    patch_input("dataset0"),
+                    patch_questionary("dataset0"),
                 ),
                 StepAndAnswer(
                     basic.MoreDatasetsStep(),

--- a/everyvoice/wizard/basic.py
+++ b/everyvoice/wizard/basic.py
@@ -30,7 +30,6 @@ from everyvoice.wizard.dataset import TextProcessingStep, get_dataset_steps
 from everyvoice.wizard.prompts import (
     CUSTOM_QUESTIONARY_STYLE,
     get_response_from_menu_prompt,
-    input,
 )
 from everyvoice.wizard.tour import Step
 from everyvoice.wizard.utils import escape, sanitize_paths, write_dict_to_config
@@ -44,7 +43,9 @@ class NameStep(Step):
         rich_print(
             "What would you like to call this project? This name should reflect the model you intend to train, e.g. 'my-sinhala-project' or 'english-french-model' or something similarly descriptive of your project?"
         )
-        return input("project name: ")
+        return questionary.text(
+            "project name: ", style=CUSTOM_QUESTIONARY_STYLE
+        ).unsafe_ask()
 
     def validate(self, response):
         if len(response) == 0:
@@ -69,7 +70,9 @@ class ContactNameStep(Step):
     REVERSIBLE = True
 
     def prompt(self):
-        return input("What is your full name? ")
+        return questionary.text(
+            "What is your full name? ", style=CUSTOM_QUESTIONARY_STYLE
+        ).unsafe_ask()
 
     def validate(self, response):
         # Some languages don't use first and last names, so we can't necessarily check that response.split() > 1
@@ -88,7 +91,10 @@ class ContactEmailStep(Step):
     REVERSIBLE = True
 
     def prompt(self):
-        return input("Please provide a contact email address for your models. ")
+        return questionary.text(
+            "Please provide a contact email address for your models. ",
+            style=CUSTOM_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     def in_unit_testing(self):
         """Skip checking deliverability when in unit testing.

--- a/everyvoice/wizard/dataset.py
+++ b/everyvoice/wizard/dataset.py
@@ -19,7 +19,6 @@ from everyvoice.wizard import TEXT_CONFIG_FILENAME_PREFIX, StepNames
 from everyvoice.wizard.prompts import (
     CUSTOM_QUESTIONARY_STYLE,
     get_response_from_menu_prompt,
-    input,
 )
 from everyvoice.wizard.tour import Step, Tour
 from everyvoice.wizard.utils import (
@@ -40,9 +39,10 @@ class DatasetNameStep(Step):
     REVERSIBLE = True
 
     def prompt(self):
-        return input(
-            "What would you like to call this dataset? This is needed because EveryVoice lets you train models with multiple sources of data. Please choose a name that distinguishes this data source, e.g. 'john-english' or 'maria-spanish' or something similarly descriptive: "
-        )
+        return questionary.text(
+            "What would you like to call this dataset? This is needed because EveryVoice lets you train models with multiple sources of data. Please choose a name that distinguishes this data source, e.g. 'john-english' or 'maria-spanish' or something similarly descriptive: ",
+            style=CUSTOM_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     def validate(self, response):
         if len(response) == 0:
@@ -589,7 +589,10 @@ class AddSpeakerStep(Step):
     REVERSIBLE = True
 
     def prompt(self):
-        return input("Please enter the desired speaker ID: ")
+        return questionary.text(
+            "Please enter the desired speaker ID: ",
+            style=CUSTOM_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     def validate(self, response):
         if len(response) == 0:
@@ -702,7 +705,10 @@ class LanguageCodeStep(Step):
     REVERSIBLE = True
 
     def prompt(self):
-        return input("Please enter the language code for this dataset's language: ")
+        return questionary.text(
+            "Please enter the language code for this dataset's language: ",
+            style=CUSTOM_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     def validate(self, response):
         if response != slugify(response):
@@ -868,7 +874,10 @@ class SelectG2PEngineStep(Step):
                 'Use Ctrl-C / "Go back one step" to keep the current settings.'
             )
         )
-        return input(f"g2p function for {self.language_code}: ")
+        return questionary.text(
+            f"g2p function for {self.language_code}: ",
+            style=CUSTOM_QUESTIONARY_STYLE,
+        ).unsafe_ask()
 
     def sanitize_input(self, response):
         return response.strip()

--- a/everyvoice/wizard/prompts.py
+++ b/everyvoice/wizard/prompts.py
@@ -2,7 +2,6 @@
 Encapsulate the logic for prompting the user for input in a simple terminal window
 """
 
-import builtins
 import sys
 from typing import Sequence
 
@@ -32,26 +31,6 @@ CUSTOM_QUESTIONARY_STYLE = Style(
         ("disabled", "fg:default"),  # disabled choices for select and checkbox prompts
     ]
 )
-
-
-def input(prompt: str = ""):
-    """Like builtins.input(), but always prints the prompt to stdout.
-
-    Without this, 'everyvoice new-project 2> error.log' sends input prompts to
-    stderr and I cannot see them anymore. Possibly never user relevant, but
-    important to EJ during development and testing.
-
-    I think this is a bug in builtins.input: the official documentation says the
-    prompt goes to stdout, but that's not true if any redirection happens.
-
-    References:
-     - https://docs.python.org/3/library/functions.html#input
-     - https://stackoverflow.com/questions/53904474/pythons-input-or-raw-input-redirect-to-stderr-instead-of-stdout
-     - https://www.reddit.com/r/learnpython/comments/lyldtc/python_input_function_writes_prompt_to_standard/
-     - https://bugs.python.org/issue1927
-    """
-    print(prompt, end="", flush=True)
-    return builtins.input()
 
 
 def get_response_from_menu_prompt(


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Use `questionary.text(xyz).ask` instead of overrided `input(xyz)`. This allows use of left and right arrow keys when running the EV wizard.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #574

### Feedback requested

Have I refactored the tests properly? `patch_input` was frequently replaced with `patch_questionary`

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Tests were simply refactored. No new functionality

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the EveryVoice wizard!

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

patch

<!-- Add any other relevant information here -->
