### PR TITLE
Dev.ej/misc fixes

### DIFF
--- a/everyvoice/base_cli/checkpoint.py
+++ b/everyvoice/base_cli/checkpoint.py
@@ -218,7 +218,9 @@ def rename_speaker(
             torch.save(ckpt, model_path)
             print(f"Updated checkpoint saved to {model_path}.")
         else:
-            raise ValueError(f"Speaker '{old_speaker_name}' not found in parameters.")
+            raise typer.BadParameter(
+                f"Speaker '{old_speaker_name}' not found in checkpoint parameters."
+            )
 
     else:
-        raise ValueError("No speakers found in checkpoint parameters.")
+        raise typer.BadParameter("No speakers found in checkpoint parameters.")

--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -711,7 +711,7 @@ def demo(
     **kwargs,
 ):
     if allowlist and denylist:
-        raise ValueError(
+        raise typer.BadParameter(
             "You provided a value for both the allowlist and the denylist but you can only provide one."
         )
 

--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -316,9 +316,9 @@ class CLITest(TestCase):
                 app, ["inspect-checkpoint", str(self.data_dir / "test.ckpt")]
             )
         self.assertEqual(result.exit_code, 0)
-        self.assertIn(
-            "This command has been renamed to `everyvoice checkpoint inspect`.",
+        self.assertRegex(
             result.stdout,
+            r"(?s)This command has been renamed to `everyvoice.*checkpoint.*inspect`",
         )
 
     def test_inspect_checkpoint_help(self):
@@ -430,7 +430,6 @@ class CLITest(TestCase):
         self.assertNotIn("['HELLO', 'WORLD']", result.stdout)
 
     def mock_create_demo_app(self, *_args, **_kwargs):
-
         class MockCreateDemoApp:
             def launch(self, *_args, **_kwargs):
                 print(f"  - Launch Port: {_kwargs['server_port']}")
@@ -457,7 +456,6 @@ class CLITest(TestCase):
                 "everyvoice.demo.app.create_demo_app",
                 side_effect=self.mock_create_demo_app,
             ):
-
                 result = self.runner.invoke(
                     app,
                     [
@@ -536,7 +534,6 @@ class CLITest(TestCase):
             torch.save(ckpt, tmpdir / "test.ckpt")
 
             with mock.patch("torch.save", side_effect=self.mock_torch_save):
-
                 # Test renaming a non-existing speaker
                 result = self.runner.invoke(
                     app,
@@ -548,12 +545,9 @@ class CLITest(TestCase):
                         "new_speaker",
                     ],
                 )
-                print(result.output)
+                # print(result.output)
                 self.assertNotEqual(result.exit_code, 0)
-                self.assertIn(
-                    result.output,
-                    "Speaker 'non_existing_speaker' not found in parameters.",
-                )
+                self.assertIn("Speaker 'non_existing_speaker' not found", result.output)
 
     def test_rename_speaker_with_no_speakers(self):
         with tempfile.TemporaryDirectory() as tmpdir_str:
@@ -566,7 +560,6 @@ class CLITest(TestCase):
             torch.save(empty_ckpt, tmpdir / "empty.ckpt")
 
             with mock.patch("torch.save", side_effect=self.mock_torch_save):
-
                 # Test renaming with no speakers in the checkpoint
                 result = self.runner.invoke(
                     app,
@@ -578,12 +571,9 @@ class CLITest(TestCase):
                         "new_speaker",
                     ],
                 )
-                print(result.output)
+                # print(result.output)
                 self.assertNotEqual(result.exit_code, 0)
-                self.assertIn(
-                    result.output,
-                    "No speakers found in checkpoint parameters.",
-                )
+                self.assertIn("No speakers found", result.output)
 
 
 class TestBaseCLIHelper(TestCase):


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Use `typer.BadParameter` when it's a clear user CLI error, not a programming error: this gives a more concise error message.

Update the wav2vec2aligner submodule to incorporate https://github.com/EveryVoiceTTS/wav2vec2aligner/pull/24

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Replaces long stack traces by short messages to the point when you run `everyvoice checkpoint rename-speaker` but specify a speaker who does not exist or the model has no speakers.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low 

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

run `everyvoice checkpoint rename-speaker` with a model that does not have a speaker, and one where the speaker you provide does not exist in the model.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/wav2vec2aligner/pull/24

<!-- Add any other relevant information here -->
