### PR TITLE
Add MacOS to matrix testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     # Create latest docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0 # fetch all commits/branches

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -1,0 +1,66 @@
+name: Run Matrix Tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: main
+
+permissions:
+  contents: read
+
+jobs:
+  matrix-ubuntu:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - uses: FedericoCarboni/setup-ffmpeg@v2
+      - run: sudo apt-get install sox libsox-dev
+      - name: Install dependencies and EveryVoice itself
+        run: |
+          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
+          pip install -e .[dev]
+      - run: pip freeze
+      - run: pip list
+      - run: cd everyvoice && python run_tests.py dev
+
+  matrix-macos:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    runs-on: macos-latest
+    defaults:
+      run:
+        # Required for conda
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
+          conda-remove-defaults: true
+      - run: conda install -y -c conda-forge sox ffmpeg
+      - uses: actions/cache@v4  # enable caching for pre-commit
+        with:
+          path: ~/Library/Caches/pip
+          key: pip-macos-${{ matrix.python-version }}
+      - run: pip install -e .[dev]
+      - run: python --version
+      - run: pip freeze
+      - run: pip list
+      - run: cd everyvoice && python run_tests.py dev

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - test
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Set up Python
@@ -86,7 +86,7 @@ jobs:
       - github-release
       - build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0 # fetch all commits/branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,6 +156,10 @@ jobs:
           miniforge-version: latest
           conda-remove-defaults: true
       - run: conda install -y -c conda-forge sox ffmpeg
+      - uses: actions/cache@v4  # enable caching for pre-commit
+        with:
+          path: ~/Library/Caches/pip
+          key: pip-macos-${{ matrix.python-version }}
       - run: pip install -e .[dev]
       - run: python --version
       - run: pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     steps:
@@ -105,6 +105,7 @@ jobs:
           || echo "The package(s) listed just above this line is/are potentially a problem."
 
   matrix:
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - name: Install dependencies and package
+      - name: Install dependencies and EveryVoice itself
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
           pip install -e .[dev]
@@ -104,7 +104,7 @@ jobs:
           ! licensecheck --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY \
           || echo "The package(s) listed just above this line is/are potentially a problem."
 
-  matrix:
+  matrix-ubuntu:
     timeout-minutes: 30
     strategy:
       matrix:
@@ -114,16 +114,43 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - run: sudo apt-get update
-      - run: sudo apt-get install --fix-missing sox libsox-dev ffmpeg
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - name: Install dependencies and package
+      - uses: FedericoCarboni/setup-ffmpeg@v2
+      - run: sudo apt-get install sox libsox-dev
+      - name: Install dependencies and EveryVoice itself
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
           pip install -e .[dev]
       - run: pip freeze
       - run: pip list
-      - run: cd everyvoice && coverage run run_tests.py dev
+      - run: cd everyvoice && python run_tests.py dev
+
+  matrix-macos:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    runs-on: macos-latest
+    defaults:
+      run:
+        # Required for conda
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
+          conda-remove-defaults: true
+      - run: conda install -y -c conda-forge sox ffmpeg
+      - run: pip install -e .[dev]
+      - run: python --version
+      - run: pip freeze
+      - run: pip list
+      - run: cd everyvoice && python run_tests.py dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,14 @@
 name: Run Tests
-permissions:
-  contents: read
+
 on:
   - push
   - pull_request
   - workflow_call
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -110,58 +111,3 @@ jobs:
           echo ""
           ! licensecheck --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY \
           || echo "The package(s) listed just above this line is/are potentially a problem."
-
-  matrix-ubuntu:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - uses: FedericoCarboni/setup-ffmpeg@v2
-      - run: sudo apt-get install sox libsox-dev
-      - name: Install dependencies and EveryVoice itself
-        run: |
-          CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
-          pip install -e .[dev]
-      - run: pip freeze
-      - run: pip list
-      - run: cd everyvoice && python run_tests.py dev
-
-  matrix-macos:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-    runs-on: macos-latest
-    defaults:
-      run:
-        # Required for conda
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-          miniforge-version: latest
-          conda-remove-defaults: true
-      - run: conda install -y -c conda-forge sox ffmpeg
-      - uses: actions/cache@v4  # enable caching for pre-commit
-        with:
-          path: ~/Library/Caches/pip
-          key: pip-macos-${{ matrix.python-version }}
-      - run: pip install -e .[dev]
-      - run: python --version
-      - run: pip freeze
-      - run: pip list
-      - run: cd everyvoice && python run_tests.py dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 on:
   - push
   - pull_request
@@ -11,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      contents: write  # for pre-commit-ci/lite-action
       pull-requests: write
     steps:
       - name: Checkout repository and submodules
@@ -35,6 +38,10 @@ jobs:
           # Only run pre-commit on EV files themselves, not on submodules
           # See https://github.com/EveryVoiceTTS/EveryVoice/issues/555
           exclude_submodules: true
+      - uses: actions/cache@v4  # enable caching for pre-commit
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Custom replacement for pre-commit/action
         # pre-commit/action is not compatible with conda-incubator/setup-miniconda because it sets the shell wrong.
         run: python -m pre_commit run --show-diff-on-failure --color=always --files ${{ steps.file_changes.outputs.all_changed_files }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - run: sudo apt-get update
@@ -111,7 +111,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - run: sudo apt-get update

--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -1,7 +1,6 @@
 import enum
 import json
 import os
-import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -707,8 +706,7 @@ class CLITest(TestCase):
                 # print(result.output, result.exit_code)  # Debug output
             self.assertNotEqual(result.exit_code, 0)
             self.assertRegex(
-                result.output,
-                rf"(?s)Your config file {re.escape(str(config_file))}.*has errors",
+                result.output, r"(?s)Your config file.*malformed.*has.*errors"
             )
 
     # unit test for error handling in load_app_ui_labels


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

We previously matrix tested three Python versions with Ubuntu, but not with MacOS. Since Macs are a pretty common EveryVoice use case, it makes sense to test it too in CI.

While I'm here, some small additional tweaks:
 - allow 30 minutes per run, because somethings our 15 minute limit is too short
 - bump actions/checkout to the latest version, @v5
 - Use FedericoCarboni/setup-ffmpeg@v2 instead of apt-get to install ffmpeg, because the former take 2s while the latter takes much longer. We don't need the latest ffmpeg, so there's no value in doing it the slower way.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

For MacOS, I'm using conda because I could not figure out how to install sox in CI any other way. If someone can figure out a more direct sox installation path, great, but otherwise this is fine as is.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

nothing but

### How to test? <!-- Explain how reviewers should test this PR. -->

look at the CI runs

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
