### PR TITLE
ci: have publish run matrix tests as a dependency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,11 +15,16 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  matrix-tests:
+    uses: ./.github/workflows/matrix-tests.yml
+    secrets: inherit
+
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
     needs:
       - test
+      - matrix-tests
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v5


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

matrix testing is now in its own workflow, so publish needs to depend on it separately

### Feedback sought? <!-- What should reviewers focus on in particular? -->

I don't want to exercise this to test it, so careful visual review of the code changes

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before next release

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

it would require changing the workflow in a separate branch where it's deactivated, and pushing a tag there. I don't want to do it for such a simple change.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no



<!-- Add any other relevant information here -->
