### PR TITLE
fix: regression resume files need the custom g2p step

### DIFF
--- a/everyvoice/tests/regression/wizard-resume-lj
+++ b/everyvoice/tests/regression/wizard-resume-lj
@@ -35,6 +35,8 @@
   - 'no'
 - - Select Language Step
   - '[eng]: English'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - wavs
 - - Validate Wavs Step

--- a/everyvoice/tests/regression/wizard-resume-mix
+++ b/everyvoice/tests/regression/wizard-resume-mix
@@ -37,6 +37,8 @@
   - 'no'
 - - Select Language Step
   - '[eng]: English'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - ../regress-lj-60/wavs
 - - Validate Wavs Step
@@ -69,6 +71,8 @@
   - 'no'
 - - Select Language Step
   - '[und]: my language isn''t here'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - ../regress-si-full/wavs
 - - Validate Wavs Step
@@ -110,6 +114,8 @@
   - 'no'
 - - Select Language Step
   - '[und]: my language isn''t here'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - ../regress-xh-full/wavs
 - - Validate Wavs Step

--- a/everyvoice/tests/regression/wizard-resume-si
+++ b/everyvoice/tests/regression/wizard-resume-si
@@ -30,6 +30,8 @@
   - 'no'
 - - Select Language Step
   - '[und]: my language isn''t here'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - wavs
 - - Validate Wavs Step

--- a/everyvoice/tests/regression/wizard-resume-xh
+++ b/everyvoice/tests/regression/wizard-resume-xh
@@ -35,6 +35,8 @@
   - 'no'
 - - Select Language Step
   - '[und]: my language isn''t here'
+- - Custom G2P Step
+  - 0
 - - Wavs Dir Step
   - wavs
 - - Validate Wavs Step


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

The regression test suites were broken because the resume files did not have the new custom g2p questions.

We need to instate a process where we run these regularly... in the meantime, this is the minimal fix to get them working again.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### How to test? <!-- Explain how reviewers should test this PR. -->

run regression tests and see that all sub-suites end with a DONE file rather than a FAILED file.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no
