### PR TITLE
perf(ci): split the test workflow into three parallel workflows

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -20,12 +20,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - uses: FedericoCarboni/setup-ffmpeg@v2
-      - run: sudo apt-get install sox libsox-dev
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: sox libsox-dev ffmpeg
       - name: Install dependencies and EveryVoice itself
         run: |
           CUDA_TAG=cpu pip install -r requirements.torch.txt --find-links https://download.pytorch.org/whl/torch_stable.html
@@ -55,7 +56,7 @@ jobs:
           miniforge-version: latest
           conda-remove-defaults: true
       - run: conda install -y -c conda-forge sox ffmpeg
-      - uses: actions/cache@v4  # enable caching for pre-commit
+      - uses: actions/cache@v4
         with:
           path: ~/Library/Caches/pip
           key: pip-macos-${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - run: sudo apt-get update
-      - run: sudo apt-get install --fix-missing sox libsox-dev ffmpeg
-      - uses: actions/setup-python@v5
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: sox libsox-dev ffmpeg
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

While working on #747, it was annoying how pre-commit and licensecheck, with no dependencies on the EV test suite, delay it and/or are delayed by it. So I refactored the workflow into three independent jobs which can start at the same time and provide their independent results faster.

Now the three independent parts of the workflow can run in parallel.

Also optimize licensecheck and pre-commit to use the default python as is, speeding up their launch.

And bring the pre-commit-ci action to the current latest version

EDIT: and use `awalsh128/cache-apt-pkgs-action@v1.5.3` to apt install packages with caching, giving us another significant action speed up.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

how quickly CI results can become available

### Feedback sought? <!-- What should reviewers focus on in particular? -->

regular review

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### How to test? <!-- Explain how reviewers should test this PR. -->

watch CI

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

