### PR TITLE
fix: make make-everyvoice-env compatible with older uv

### DIFF
--- a/make-everyvoice-env
+++ b/make-everyvoice-env
@@ -214,7 +214,7 @@ r() {
 set -o errexit
 
 if [[ $USE_UV ]]; then
-    r uv venv --managed-python --python="$PYTHON_VERSION" "$ENV_PREFIX"
+    r uv venv --python-preference=only-managed --python="$PYTHON_VERSION" "$ENV_PREFIX"
     r source "$ENV_PREFIX"/*/activate
 
     if [[ $CUDA_TAG ]]; then


### PR DESCRIPTION

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

The `--managed-python` option to `uv` is a newish (introduced with 0.6.8) alias to `--python-preference=only-managed`, so use that version instead to be compatible with older versions of `uv`.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #756

### Feedback sought? <!-- What should reviewers focus on in particular? -->

test it with the old uv that caused trouble and confirm it works

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

install uv older than 0.6.8 and run `./make-everyvoice-env --uv`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
