### PR TITLE
build(deps): remove dependency on unused pystdw and pycountry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,8 @@ dependencies = [
   "packaging>=22.0",
   "pandas~=2.0",
   "protobuf~=4.25",                # https://github.com/EveryVoiceTTS/EveryVoice/issues/387
-  "pycountry==22.3.5",
   "pydantic[email]>=2.4.2,<2.8.0",
   "pympi-ling",
-  "pysdtw==0.0.5",
   "pyworld-prebuilt==0.3.4.4",
   "PyYAML>=6.0",
   "readalongs>=1.2.0",


### PR DESCRIPTION

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Remove two dependencies we no longer actually use: pystdw and pycountry

We stopped using pystdw's SoftDTW in 2022 when we changed the fs2 loss function. (See commit history of fs2/loss.py for details.)

We stopped usign pycountry in 2023 when we started just relying on g2p for the list of languages. (See commit history of everyvoice/cli.py for details.)

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping, and CI output

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

CI does it

### How to test? <!-- Explain how reviewers should test this PR. -->

Fresh install, or `pip uninstall pycountry pystdw` and then `pytest`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

nah

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

nope

<!-- Add any other relevant information here -->
