### PR TITLE
refactor(ci): move the speed test into a separate script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           coverage xml
       - run: cd everyvoice && coverage report
       - name: Check for logs_and_checkpoints/ and preprocessed/
-        id: no-extra-directories
         run: |
           find -type d -name logs_and_checkpoints -or -name preprocessed | grep -v 'tests/data' || true
           [[ $(find -type d -name logs_and_checkpoints -or -name preprocessed | grep --count --invert-match 'tests/data') -eq 0 ]]
@@ -58,27 +57,7 @@ jobs:
           fail_ci_if_error: false # optional (default = false)
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Make sure the CLI stays fast
-        id: cli-load-time
-        run: |
-          PYTHONPROFILEIMPORTTIME=1 everyvoice -h 2> importtime.txt > /dev/null
-          CLI_LOAD_TIME="$((/usr/bin/time --format=%E everyvoice -h > /dev/null) 2>&1)"
-          echo "CLI load time: $CLI_LOAD_TIME" > import-message.txt
-          PR_HEAD="${{ github.event.pull_request.head.sha }}"
-          [[ $PR_HEAD ]] && echo "Pull Request HEAD: $PR_HEAD" >> import-message.txt
-          echo "Imports that take more than 0.1 s:" >> import-message.txt
-          grep -E 'cumulative|[0-9]{6} ' importtime.txt >> import-message.txt
-          cat import-message.txt
-          echo "Full import time log:"
-          cat importtime.txt
-          if [[ "$CLI_LOAD_TIME" > "0:01.00" ]]; then \
-            echo "ERROR: everyvoice --help is too slow."; \
-            echo "Please run 'PYTHONPROFILEIMPORTTIME=1 everyvoice -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."; \
-            false; \
-          fi
-          if grep -E -q "shared_types|pydantic" importtime.txt; then \
-            echo "ERROR: please be careful not to cause shared_types or pydantic to be imported when the CLI just loads. They are expensive imports."; \
-            false; \
-          fi
+        run: ./profile-help-ci.sh "${{ github.event.pull_request.head.sha }}"
       - name: Report help speed in PR
         if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@7c1a3a3e5a072270dc21c0639df39ca11e860b2b # v3.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ everyvoice/tests/data/lj/preprocessed/*
 site/
 *env*/
 !everyvoice/tests/data/test.ckpt
+import-message.txt
+importtime.txt

--- a/profile-help-ci.sh
+++ b/profile-help-ci.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Usage:
+# - make the `everyvoice` command available on the path (e.g., activate your uv venv)
+# - run: ./profile-help-ci.sh "${{ github.event.pull_request.head.sha }}"
+# - display `import-message.txt` as a PR comment (see .github/workflows/text.yml)
+
+PYTHONPROFILEIMPORTTIME=1 everyvoice -h 2> importtime.txt > /dev/null
+CLI_LOAD_TIME="$( (/usr/bin/time --format=%E everyvoice -h > /dev/null) 2>&1 )"
+
+{
+    echo "CLI load time: $CLI_LOAD_TIME"
+    PR_HEAD="$1"
+    [[ $PR_HEAD ]] && echo "Pull Request HEAD: $PR_HEAD"
+    echo ""
+    echo "Imports that take more than 0.1 s:"
+    grep -E 'cumulative|[0-9]{6} ' importtime.txt
+} > import-message.txt
+cat import-message.txt
+
+echo ""
+echo "Full import time log:"
+cat importtime.txt
+
+EXIT_CODE=
+if [[ "$CLI_LOAD_TIME" > "0:01.00" ]]; then
+    echo ""
+    echo "ERROR: everyvoice --help is too slow."
+    echo "Please run 'PYTHONPROFILEIMPORTTIME=1 everyvoice -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."
+    EXIT_CODE=1
+fi
+if grep -E -q "shared_types|pydantic" importtime.txt; then
+    echo ""
+    echo "ERROR: please be careful not to cause shared_types or pydantic to be imported when the CLI just loads. They are expensive imports."
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Factor out the code to check the time it takes to run `everyvoice -h` to make sure it stays fast

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

legibility, plus the .sh script is lintable

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

Mostly look at the output of the "Make sure the CLI stays fast" step in CI, and the PR comment. They should stay as before.

You can also run `./profile-help-ci.sh` but better pipe the output into less, it's optimized for CI logs, not interactive use. This will leave around two text files, `importtime.txt` and `import-message.txt`. That's on purpose, and they're now .gitignore'd. You can use them for analysis of what's wrong in your PR, too, if your PR is slowing things down.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

pretty good

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

nope

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

nope

<!-- Add any other relevant information here -->
