### PR TITLE
ci: update setup-miniconda for node 24 bump

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

[conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda) finally released a patch fully using node 24, let's bump.

### Editorial comment

We only use conda in CI for MacOS in matrix testing, where I have not succeeded in using non-conda solutions to install sox. But I'd love to move off of Conda completely here too, looking for a contributor to do it, without loosing too much efficiency. 

Expected results: replacing conda by alternative sox and ffmpeg installers and uv for the python packages would most likely speed up the workflow, but my expectations are often wrong for what's fast or slow in CI... So dang unpredictable!

### Feedback sought?

Rubber stamping for the PR, a maybe volunteer for addressing my editorial comment.
