### PR TITLE
ci: on MacOS, use brew install ffmpeg and sox; remove conda

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,26 +42,17 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false
     runs-on: macos-latest
-    defaults:
-      run:
-        # Required for conda
-        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+      - run: brew install ffmpeg sox
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-version: latest
-          conda-remove-defaults: true
-      - run: conda install -y -c conda-forge sox ffmpeg
-      - uses: actions/cache@v5
-        with:
-          path: ~/Library/Caches/pip
-          key: pip-macos-${{ matrix.python-version }}
+          cache: "pip"
       - run: pip install -e .[dev]
       - run: python --version
       - run: pip freeze


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This PR replaces #800: instead of updating setup-miniconda, remove it! In the past, `brew install sox` did not work, with `libsox.so` not being found, but since we don't need libsox.so anymore, that problem is moot.

So now our matrix tests for MacOS just use the standard setup-python, with `brew install ffmpeg sox` for those dependencies, rather than conda. Brew turns out to be faster.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity check

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Look at the CI logs for the matrix-tests workflow: https://github.com/EveryVoiceTTS/EveryVoice/actions/runs/25517910389

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

