### PR TITLE
[StyleTTS2] load pretrained checkpoint from HuggingFace

### DIFF
--- a/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
+++ b/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
@@ -445,6 +445,61 @@
       "title": "Punctuation",
       "type": "object"
     },
+    "StyleTTS2ASRConfig": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Source for the ASR text-aligner checkpoint.",
+      "properties": {
+        "repo_id": {
+          "default": "everyvoice/styletts2-asr-aligner",
+          "description": "HuggingFace repo ID for the ASR text-aligner.",
+          "title": "Repo Id",
+          "type": "string"
+        },
+        "checkpoint_filename": {
+          "default": "epoch_00080.pth",
+          "description": "Filename of the model checkpoint within the HuggingFace repo.",
+          "title": "Checkpoint Filename",
+          "type": "string"
+        },
+        "config_filename": {
+          "default": "config.yml",
+          "description": "Filename of the model config within the HuggingFace repo.",
+          "title": "Config Filename",
+          "type": "string"
+        },
+        "local_checkpoint": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename.",
+          "title": "Local Checkpoint"
+        },
+        "local_config": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Local path to the config file. If set, overrides repo_id/config_filename.",
+          "title": "Local Config"
+        }
+      },
+      "title": "StyleTTS2ASRConfig",
+      "type": "object"
+    },
     "StyleTTS2DecoderConfig": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -653,6 +708,41 @@
       "title": "StyleTTS2DiffusionTransformerConfig",
       "type": "object"
     },
+    "StyleTTS2JDCConfig": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Source for the JDC F0 extractor checkpoint.",
+      "properties": {
+        "repo_id": {
+          "default": "everyvoice/styletts2-jdc-f0",
+          "description": "HuggingFace repo ID for the JDC F0 extractor.",
+          "title": "Repo Id",
+          "type": "string"
+        },
+        "filename": {
+          "default": "bst.t7",
+          "description": "Filename of the checkpoint within the HuggingFace repo.",
+          "title": "Filename",
+          "type": "string"
+        },
+        "local_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Local path to the checkpoint. If set, overrides repo_id/filename.",
+          "title": "Local Path"
+        }
+      },
+      "title": "StyleTTS2JDCConfig",
+      "type": "object"
+    },
     "StyleTTS2LossConfig": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -845,38 +935,89 @@
       "title": "StyleTTS2OptimizerConfig",
       "type": "object"
     },
+    "StyleTTS2PLBERTConfig": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "description": "Source for the PLBERT text encoder checkpoint.",
+      "properties": {
+        "repo_id": {
+          "default": "papercup-ai/multilingual-pl-bert",
+          "description": "HuggingFace repo ID for the PLBERT text encoder.",
+          "title": "Repo Id",
+          "type": "string"
+        },
+        "checkpoint_filename": {
+          "default": "step_1000000.t7",
+          "description": "Filename of the checkpoint within the HuggingFace repo.",
+          "title": "Checkpoint Filename",
+          "type": "string"
+        },
+        "config_filename": {
+          "default": "config.yml",
+          "description": "Filename of the model config within the HuggingFace repo.",
+          "title": "Config Filename",
+          "type": "string"
+        },
+        "local_checkpoint": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename.",
+          "title": "Local Checkpoint"
+        },
+        "local_config": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Local path to the config file. If set, overrides repo_id/config_filename.",
+          "title": "Local Config"
+        }
+      },
+      "title": "StyleTTS2PLBERTConfig",
+      "type": "object"
+    },
     "StyleTTS2PretrainedConfig": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
-      "description": "Paths to the frozen pretrained models bundled with StyleTTS2.",
+      "description": "Sources for the frozen pretrained models used by StyleTTS2.",
       "properties": {
-        "f0_path": {
-          "default": "styletts2/pretrained/jdc/bst.t7",
-          "description": "Path to the JDC F0 extractor checkpoint.",
-          "format": "path",
-          "title": "F0 Path",
-          "type": "string"
+        "f0": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/StyleTTS2JDCConfig"
+            }
+          ],
+          "description": "JDC F0 extractor source (HuggingFace repo or local path)."
         },
-        "asr_config": {
-          "default": "styletts2/pretrained/asr/config.yml",
-          "description": "Path to the ASR model config.",
-          "format": "path",
-          "title": "Asr Config",
-          "type": "string"
+        "asr": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/StyleTTS2ASRConfig"
+            }
+          ],
+          "description": "ASR text-aligner source (HuggingFace repo or local paths)."
         },
-        "asr_path": {
-          "default": "styletts2/pretrained/asr/epoch_00080.pth",
-          "description": "Path to the ASR model checkpoint.",
-          "format": "path",
-          "title": "Asr Path",
-          "type": "string"
-        },
-        "plbert_dir": {
-          "default": "styletts2/pretrained/plbert",
-          "description": "Directory containing the PLBERT checkpoint and config.",
-          "format": "path",
-          "title": "Plbert Dir",
-          "type": "string"
+        "plbert": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/StyleTTS2PLBERTConfig"
+            }
+          ],
+          "description": "PLBERT text encoder source (HuggingFace repo or local paths)."
         },
         "pretrained_symbols": {
           "description": "Ordered symbol list that matches the pretrained text-encoder embedding table. The index of each symbol here is its embedding-table row. Override only if you are using a custom pretrained text encoder.",

--- a/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
+++ b/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
@@ -947,7 +947,7 @@
           "type": "string"
         },
         "checkpoint_filename": {
-          "default": "step_1000000.t7",
+          "default": "step_1100000.t7",
           "description": "Filename of the checkpoint within the HuggingFace repo.",
           "title": "Checkpoint Filename",
           "type": "string"

--- a/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
+++ b/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
@@ -479,7 +479,7 @@
             }
           ],
           "default": null,
-          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename.",
+          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename. Warning: this path is expanded (via os.path.expandvars and os.path.expanduser) when the config is loaded, and the resolved absolute path is what gets embedded in saved checkpoints. This may make your checkpoints less portable to other machines. Environment variables (e.g. $HOME or ${MY_MODELS}) and '~' are supported.",
           "title": "Local Checkpoint"
         },
         "local_config": {
@@ -493,7 +493,7 @@
             }
           ],
           "default": null,
-          "description": "Local path to the config file. If set, overrides repo_id/config_filename.",
+          "description": "Local path to the config file. If set, overrides repo_id/config_filename. Warning: this path is expanded (via os.path.expandvars and os.path.expanduser) when the config is loaded, and the resolved absolute path is what gets embedded in saved checkpoints. This may make your checkpoints less portable to other machines. Environment variables (e.g. $HOME or ${MY_MODELS}) and '~' are supported.",
           "title": "Local Config"
         }
       },
@@ -736,7 +736,7 @@
             }
           ],
           "default": null,
-          "description": "Local path to the checkpoint. If set, overrides repo_id/filename.",
+          "description": "Local path to the checkpoint. If set, overrides repo_id/filename. Warning: this path is expanded (via os.path.expandvars and os.path.expanduser) when the config is loaded, and the resolved absolute path is what gets embedded in saved checkpoints. This may make your checkpoints less portable to other machines. Environment variables (e.g. $HOME or ${MY_MODELS}) and '~' are supported.",
           "title": "Local Path"
         }
       },
@@ -969,7 +969,7 @@
             }
           ],
           "default": null,
-          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename.",
+          "description": "Local path to the checkpoint file. If set, overrides repo_id/checkpoint_filename. Warning: this path is expanded (via os.path.expandvars and os.path.expanduser) when the config is loaded, and the resolved absolute path is what gets embedded in saved checkpoints. This may make your checkpoints less portable to other machines. Environment variables (e.g. $HOME or ${MY_MODELS}) and '~' are supported.",
           "title": "Local Checkpoint"
         },
         "local_config": {
@@ -983,7 +983,7 @@
             }
           ],
           "default": null,
-          "description": "Local path to the config file. If set, overrides repo_id/config_filename.",
+          "description": "Local path to the config file. If set, overrides repo_id/config_filename. Warning: this path is expanded (via os.path.expandvars and os.path.expanduser) when the config is loaded, and the resolved absolute path is what gets embedded in saved checkpoints. This may make your checkpoints less portable to other machines. Environment variables (e.g. $HOME or ${MY_MODELS}) and '~' are supported.",
           "title": "Local Config"
         }
       },

--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -220,6 +220,7 @@ def main(
 @app.command(
     short_help="Evaluate your synthesized audio",
     name="evaluate",
+    no_args_is_help=True,
     help="""
     # Evalution help
 
@@ -275,9 +276,11 @@ def evaluate(
         subjective_model, s_sr = load_squim_subjective_model()
         HEADERS.append("MOS")
 
-    if audio_file and audio_directory:
+    if (audio_file and audio_directory) or (
+        audio_file is None and audio_directory is None
+    ):
         print(
-            "Sorry, please choose to evaluate either a single file or an entire directory. Got values for both."
+            "Sorry, please choose to evaluate either a single file or an entire directory."
         )
         sys.exit(1)
 
@@ -472,6 +475,7 @@ def new_project(
 # Add preprocess to root
 app.command(
     short_help="Preprocess your data",
+    no_args_is_help=True,
     help=f"""
     # Preprocess Help
 
@@ -492,6 +496,7 @@ app.command(
 app.command(
     "check-data",
     short_help="Check your data for outliers or any anomalies",
+    no_args_is_help=True,
     help="""
     # Check Data Help
 
@@ -928,6 +933,7 @@ def _run_fs2_demo(
 
 @app.command(
     name="demo",
+    no_args_is_help=True,
     short_help="Launch an interactive Gradio demo for any EveryVoice model",
 )
 @merge_args(inference_base_command_interface)
@@ -1197,7 +1203,9 @@ def update_schemas(
         )
 
 
-@app.command()
+@app.command(
+    no_args_is_help=True,
+)
 def g2p(
     lang_id: Annotated[str, typer.Argument(help="language id")],
     # Ignoring mypy since class FileText(io.TextIOWrapper)

--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -35,6 +35,9 @@ from everyvoice.model.aligner.wav2vec2aligner.aligner.cli import (
 from everyvoice.model.aligner.wav2vec2aligner.aligner.cli import (
     extract_segments_from_textgrid,
 )
+from everyvoice.model.e2e.StyleTTS2_lightning.styletts2.cli.fetch_pretrained import (
+    fetch_pretrained as fetch_pretrained_styletts2,
+)
 from everyvoice.model.e2e.StyleTTS2_lightning.styletts2.cli.synthesize import (
     synthesize as synthesize_styletts2,
 )
@@ -601,6 +604,34 @@ app.add_typer(
     synthesize_group,
     name="synthesize",
     short_help="Synthesize using your pre-trained EveryVoice models",
+)
+
+# Add fetch-pretrained commands
+fetch_pretrained_group = typer.Typer(
+    pretty_exceptions_show_locals=False,
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    rich_markup_mode="markdown",
+    cls=TyperGroupOrderAsDeclared,
+    help="""
+    # Fetch Pretrained Models
+
+    Download pretrained model weights from HuggingFace before running a training
+    job on a cluster node that has no internet access.  Run this command on the
+    head node first; the files are cached by the HuggingFace hub and reused
+    automatically during training.
+    """,
+)
+
+fetch_pretrained_group.command(
+    name="text-to-wav",
+    short_help="Download pretrained weights for StyleTTS2 training",
+)(fetch_pretrained_styletts2)
+
+app.add_typer(
+    fetch_pretrained_group,
+    name="fetch-pretrained",
+    short_help="Download pretrained model weights from HuggingFace",
 )
 
 # Add the checkpoint commands

--- a/everyvoice/tests/data/relative/config/everyvoice-text-to-wav.yaml
+++ b/everyvoice/tests/data/relative/config/everyvoice-text-to-wav.yaml
@@ -55,11 +55,7 @@ preprocessing:
     - [channels, '1']
   train_split: 0.9
 pretrained:
-  asr_config: styletts2/pretrained/asr/config.yml
-  asr_path: styletts2/pretrained/asr/epoch_00080.pth
-  f0_path: styletts2/pretrained/jdc/bst.t7
-  plbert_dir: styletts2/pretrained/plbert
-  pretrained_symbols: [$, ;, ':', ',', ., '!', '?', ¡, ¿, —, …, '"', «, », “, ”, ' ',
+  pretrained_symbols: [$, ;, ':', ',', ., '!', '?', ¡, ¿, —, …, '”', «, », “, “, ' ',
     A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
     a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z,
     ɑ, ɐ, ɒ, æ, ɓ, ʙ, β, ɔ, ɕ, ç, ɗ, ɖ, ð, ʤ, ə, ɘ, ɚ, ɛ, ɜ, ɝ, ɞ, ɟ, ʄ, ɡ, ɠ, ɢ,

--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -463,10 +463,11 @@ class CLITest(TestCase):
         self.assertNotIn(b"pydantic", result.stderr, msg.format("pydantic"))
 
     def test_demo_with_bad_args(self):
-        # No checkpoint → missing argument
+        # No checkpoint → help message
         result = self.runner.invoke(app, ["demo"])
-        assert result.exit_code != 0
-        assert "Missing argument" in result.output
+        assert result.exit_code == 0
+        # the runner calls "root" instead of "everyvoice"
+        assert "Usage: root demo [OPTIONS] CHECKPOINT" in flatten_log(result.output)
 
         # Invalid --output-format value
         result = self.runner.invoke(

--- a/everyvoice/wizard/basic.py
+++ b/everyvoice/wizard/basic.py
@@ -477,12 +477,8 @@ class ConfigFormatStep(Step):
 
             # E2E Config
             from everyvoice.model.e2e import StyleTTS2_lightning
-            from everyvoice.model.e2e.config import (
-                StyleTTS2PretrainedConfig,
-            )
 
             st_dir = Path(StyleTTS2_lightning.__path__[0])
-            pretrained_folder = st_dir / "styletts2" / "pretrained"
 
             e2e_logger = LoggerConfig(
                 name="E2E-Experiment", save_dir=log_dir_relative_to_configs
@@ -491,12 +487,6 @@ class ConfigFormatStep(Step):
                 contact=CONTACT_INFO,
                 model=StyleTTS2ModelConfig(multispeaker=multispeaker),
                 preprocessing=preprocessing_config,  # TODO: should we use the default 24kHz sampling rate that StyleTTS2 usually uses? if so, the hop size, upsample rates etc will also need to change
-                pretrained=StyleTTS2PretrainedConfig(
-                    f0_path=pretrained_folder / "jdc/bst.t7",
-                    asr_config=pretrained_folder / "asr/config.yml",
-                    asr_path=pretrained_folder / "asr/epoch_00080.pth",
-                    plbert_dir=pretrained_folder / "plbert",
-                ),
                 training=StyleTTS2TrainingConfig(
                     ood_data=st_dir
                     / "data"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Loading pretrained models from within the codebase is messy since we need to handle the paths, and the model checkpoints bloat the package/our git history.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

An element of #686 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Does this look reasonable? I think the "local override" option is still not going to be handled well since it will put a potentially absolute path in the config.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None

### How to test? <!-- Explain how reviewers should test this PR. -->

if you train a model with this branch, you should see the HF models downloading automatically

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

n/a

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/StyleTTS2/pull/6

<!-- Add any other relevant information here -->

Once accepted, we'll need to clean the git history of any *.t7 or *.pth files