### PR TITLE
ci: alternative way to install ffmpeg on failure in matrix too

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           packages: sox
       - uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # @v3.1, with tool cache
+        id: ffmpeg
+        continue-on-error: true
+      - name: Alternate way to install ffmpeg if need be
+        if: steps.ffmpeg.outcome == 'failure'
+        run: sudo apt-get update && sudo apt-get install ffmpeg
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

CI fails too often when we cannot install ffmpeg. I installed this alternative thing in tests.yaml before, now extending it to matrix testing too.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no
