### PR TITLE
Fix licensecheck installation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,15 +152,18 @@ jobs:
         with:
           sparse-checkout: pyproject.toml
           submodules: false
-      - run: pip install licensecheck --no-warn-conflicts
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.21"
       - name: Run license check overall
         run: |
-          licensecheck --requirements-paths pyproject.toml --zero \
-            --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio \
+          uvx licensecheck --requirements-paths pyproject.toml --zero \
+            --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools \
             --skip-dependencies llvmlite \
             --ignore-licenses OTHER/PROPRIETARY || \
           ! echo "Package(s) listed with an X above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."
       - name: Make sure the PROPRIETARY packages are the known ones
         run: |
-          ! licensecheck --requirements-paths pyproject.toml --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY || \
+          ! uvx licensecheck --requirements-paths pyproject.toml --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY || \
           ! echo "Package(s) listed above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Since this morning, licensecheck fails to run correctly in CI. I tried various solution, and finally landed on `uvx` as the one that works. I could try to figure out why the other options are broken, but see no need since this one works.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

licensecheck CI

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high -- this will block all PRs until it is fixed

### How to test? <!-- Explain how reviewers should test this PR. -->

see that CI no longer fails on the `licensecheck` job.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
