### PR TITLE
Bump setup-uv and uv consistently in all actions

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -34,10 +34,9 @@ jobs:
         if: steps.ffmpeg.outcome == 'failure'
         run: sudo apt-get update && sudo apt-get install ffmpeg
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # Install a specific version of uv.
-          version: "0.11.8"
+          version: "0.11.21"
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - run: uv pip freeze
@@ -60,10 +59,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # Install a specific version of uv.
-          version: "0.11.8"
+          version: "0.11.21"
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - run: uv pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # Install a specific version of uv.
-          version: "0.11.8"
+          version: "0.11.21"
       - name: Install the project
         run: uv sync --locked
       - run: uv pip freeze
@@ -100,10 +99,9 @@ jobs:
       - name: Verify SoX installation
         run: sox --version
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # Install a specific version of uv.
-          version: "0.11.8"
+          version: "0.11.21"
       - name: Install the project
         run: uv sync --locked --extra test
       - run: uv pip freeze


### PR DESCRIPTION
### Purpose

Bump uv to latest everywhere in actions, not just for licensecheck

In #820 I used the latest setup-uv and uv to fix licensecheck. I also want to consistently bump it everywhere, but I moved that to a separate PR to avoid muddling the intent of the PR.

### Related PR

https://github.com/EveryVoiceTTS/FastSpeech2_lightning/pull/146
