### PR TITLE
fix(ci): lock licensecheck to working version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
           version: "0.11.21"
       - name: Run license check overall
         run: |
-          uvx licensecheck --requirements-paths pyproject.toml --zero \
+          uvx licensecheck==2026.0.1 --requirements-paths pyproject.toml --zero \
             --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools \
             --skip-dependencies llvmlite \
             --ignore-licenses OTHER/PROPRIETARY || \


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

licensecheck 2026.0.2 and 2026.0.3, published yesterday, are broken. Lock to 2026.0.1 until they fix things.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

licensecheck test in CI, broken once again!

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

