### PR TITLE
Wizard: allow the user to recover from a stale resume file

### DIFF
--- a/everyvoice/tests/test_wizard.py
+++ b/everyvoice/tests/test_wizard.py
@@ -2306,9 +2306,19 @@ class WizardTest(WizardTestBase):
                 f.write("".join(progress_lines[:-4]))
                 f.write("".join(progress_lines[-2:]))
                 f.write("".join(progress_lines[-4:-2]))
-            with self.assertRaises(SystemExit), capture_stdout() as out:
+            with (
+                self.assertRaises(SystemExit),
+                patch_menu_prompt(1),  # Abort when out of sync
+                capture_stdout() as out,
+            ):
                 tour.run(resume_from=questions_out_of_order)
             assert "out of sync" in out.getvalue()
+
+            # But we can also recover from out of sync now
+            with patch_menu_prompt(0):  # Continue anyway when out of sync
+                with patch_questionary(["project_name", "Jane Doe", "email@mail.com"]):
+                    tour.run(resume_from=questions_out_of_order)
+            assert tour.state == self.trivial_tour_results
 
             extra_question_not_in_tour = tmpdir / "extra-question"
             with open(extra_question_not_in_tour, "w", encoding="utf8") as f:

--- a/everyvoice/wizard/basic.py
+++ b/everyvoice/wizard/basic.py
@@ -815,14 +815,14 @@ class ConfigFormatStep(Step):
                     (config_dir / e2e_config_path).absolute(),
                 )
 
-            rich_print(
-                Panel(
-                    f"You've finished configuring your dataset. Your files are located at {config_dir.absolute()}",
-                    title="Congratulations 🎉",
-                    subtitle="Next Steps Documentation: https://docs.everyvoice.ca/stable/guides",
-                    border_style=Style(color="#0B4F19"),
-                )
+        rich_print(
+            Panel(
+                f"You've finished configuring your dataset. Your files are located at {config_dir.absolute()}",
+                title="Congratulations 🎉",
+                subtitle="Next Steps Documentation: https://docs.everyvoice.ca/stable/guides",
+                border_style=Style(color="#0B4F19"),
             )
+        )
 
 
 class MoreDatasetsStep(Step):

--- a/everyvoice/wizard/tour.py
+++ b/everyvoice/wizard/tour.py
@@ -371,11 +371,20 @@ class Tour:
         while node is not None and q_and_a is not None:
             saved_node_name, saved_response = q_and_a
             if saved_node_name.lower() != node.name.lower():
-                rich_print(
-                    f"Error: next tour question is {node.name} but resume list has {saved_node_name} instead.\n"
-                    "Your resume-from file is likely out of sync. Aborting."
+                action = get_response_from_menu_prompt(
+                    f"[red]Error: the next tour question is {node.name} but the resume list has {saved_node_name} instead.\n"
+                    "Your resume-from file is likely out of sync.[/red]\n"
+                    "What would you like to do?",
+                    [
+                        "Continue from here",
+                        "Abort",
+                    ],
+                    return_indices=True,
                 )
-                sys.exit(1)
+                if action == 0:
+                    return node
+                else:
+                    sys.exit(1)
             if node.validate(saved_response):
                 if node.name != "Root":
                     rich_print(


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

It's poor UX that when you have a resume file from a previous version of EV, you have to edit it by hand because a new question got added, especially if that question is near the end like in the OOD case.

This PR prompts you to decide if you want to continue from the discrepancy point or not.

Also, while testing this, I noticed the spinner at the end of the wizard made the congrats message get printed wrong -- it just had to be printed after the spinner was done instead of inside the spinner scope.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

in the regression suite, the OOD PR makes the resume files stale. With this PR they work anyway until the OOD question and then you can pick from there by hand.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

no

<!-- Add any other relevant information here -->
