### PR TITLE
bump licensecheck and simplify how we use it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,12 +155,12 @@ jobs:
           version: "0.11.21"
       - name: Run license check overall
         run: |
-          uvx licensecheck==2026.0.1 --requirements-paths pyproject.toml --zero \
+          uvx licensecheck --requirements-paths pyproject.toml --zero \
             --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools \
-            --skip-dependencies llvmlite \
             --ignore-licenses OTHER/PROPRIETARY || \
           ! echo "Package(s) listed with an X above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."
       - name: Make sure the PROPRIETARY packages are the known ones
         run: |
-          ! uvx licensecheck --requirements-paths pyproject.toml --format csv 2> /dev/null | grep -v -E 'nvidia-|aiohappyeyeballs' | grep PROPRIETARY || \
+          uvx licensecheck --requirements-paths pyproject.toml --format csv > licenselog.csv
+          ! grep -v -E 'nvidia-|aiohappyeyeballs' < licenselog.csv | grep PROPRIETARY || \
           ! echo "Package(s) listed above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,11 +156,5 @@ jobs:
       - name: Run license check overall
         run: |
           uvx licensecheck --requirements-paths pyproject.toml --zero \
-            --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools \
-            --ignore-licenses OTHER/PROPRIETARY || \
+            --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools 'nvidia-*' \
           ! echo "Package(s) listed with an X above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."
-      - name: Make sure the PROPRIETARY packages are the known ones
-        run: |
-          uvx licensecheck --requirements-paths pyproject.toml --format csv > licenselog.csv
-          ! grep -v -E 'nvidia-|aiohappyeyeballs' < licenselog.csv | grep PROPRIETARY || \
-          ! echo "Package(s) listed above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

take advantage of the fact several licensecheck bugs have been fixed, and simplify our workflow using it

 - we can ignore with a wildcard, e.g., `nvidia-*`, which is much simpler than first ignoring all proprietery licenses and then checking they were the right ones
 - with licensecheck >= 2026.0.5, llvmlite is not parsed correctly so we no longer need to skip it
