### PR TITLE
Dev.ej/fix regression

### DIFF
--- a/everyvoice/tests/regression/go.sh
+++ b/everyvoice/tests/regression/go.sh
@@ -43,7 +43,7 @@ for DIR in regress-*; do
     popd
 done
 
-coverage run -p -m everyvoice test 2>&1
+coverage run -p -m pytest ../../../.. 2>&1
 
 JOB_COUNT=$(find . -maxdepth 1 -name regress-\* | wc -l)
 while true; do

--- a/everyvoice/tests/regression/regression-test.sh
+++ b/everyvoice/tests/regression/regression-test.sh
@@ -31,8 +31,7 @@ r() {
     return $rc
 }
 
-echo "Start at $(date)"
-date > START
+echo "Start at $(date)" | tee START
 
 trap 'echo "Failed or killed at $(date)"; date | tee FAILED > DONE' 0
 
@@ -51,7 +50,8 @@ cd regress || { echo "ERROR: Cannot cd into regress directory, aborting."; exit 
 trap 'echo "Failed or killed at $(date)"; date | tee ../FAILED > ../DONE' 0
 
 # Preprocess
-r "coverage run -p -m everyvoice preprocess config/everyvoice-text-to-spec.yaml"
+r "coverage run -p -m everyvoice preprocess text-to-spec config/everyvoice-text-to-spec.yaml" ||
+{ echo ERROR: Preprocess failed, aborting.; exit 1; }
 
 # Train the fs2 model
 r "coverage run -p -m everyvoice train text-to-spec config/everyvoice-text-to-spec.yaml --config-args training.max_steps=$MAX_STEPS --config-args training.max_epochs=$MAX_EPOCHS"
@@ -94,6 +94,5 @@ fi
 # TODO: use coverage analysis to find the next priority things to add here
 
 
-echo "Done at $(date)"
-date > ../DONE
+echo "Done at $(date)" | tee ../DONE
 trap - 0

--- a/everyvoice/tests/regression/regression-test.sh
+++ b/everyvoice/tests/regression/regression-test.sh
@@ -81,6 +81,7 @@ r "coverage run -p -m everyvoice synthesize from-spec \
 
 # Spin up the demo and exercise it with Playwright in headless mode
 if [[ -f ../run-demo-app.sh && -f ../test-demo-app.py ]]; then
+    export LC_ALL=C  # gradio is locale aware, but test with default English aria-labels
     bash ../run-demo-app.sh &
     DEMO_PID=$!
     sleep 10

--- a/everyvoice/tests/regression/wizard-resume-lj
+++ b/everyvoice/tests/regression/wizard-resume-lj
@@ -1,5 +1,5 @@
 - - EveryVoice Wizard
-  - 0.2.0a1
+  - 0.5.0
 - - Root
   - null
 - - Name Step
@@ -50,5 +50,7 @@
   - lj2k
 - - More Datasets Step
   - 'no'
+- - OOD Data Step [eng]
+  - 'validation: use the validation set data'
 - - Config Format Step
   - 'yaml'

--- a/everyvoice/tests/regression/wizard-resume-mix
+++ b/everyvoice/tests/regression/wizard-resume-mix
@@ -1,5 +1,5 @@
 - - EveryVoice Wizard
-  - 0.2.0a1
+  - 0.5.0
 - - Root
   - null
 - - Name Step
@@ -128,5 +128,9 @@
   - xh
 - - More Datasets Step
   - 'no'
+- - OOD Data Step [eng]
+  - 'validation: use the validation set data'
+- - OOD Data Step [und]
+  - 'validation: use the validation set data'
 - - Config Format Step
   - 'yaml'

--- a/everyvoice/tests/regression/wizard-resume-si
+++ b/everyvoice/tests/regression/wizard-resume-si
@@ -1,5 +1,5 @@
 - - EveryVoice Wizard
-  - 0.2.0a1
+  - 0.5.0
 - - Root
   - null
 - - Name Step
@@ -46,5 +46,7 @@
   - sinhala-regress
 - - More Datasets Step
   - 'no'
+- - OOD Data Step [und]
+  - 'validation: use the validation set data'
 - - Config Format Step
   - 'yaml'

--- a/everyvoice/tests/regression/wizard-resume-xh
+++ b/everyvoice/tests/regression/wizard-resume-xh
@@ -1,5 +1,5 @@
 - - EveryVoice Wizard
-  - 0.2.0a1
+  - 0.5.0
 - - Root
   - null
 - - Name Step
@@ -51,5 +51,7 @@
   - xho-regress
 - - More Datasets Step
   - 'no'
+- - OOD Data Step [und]
+  - 'validation: use the validation set data'
 - - Config Format Step
   - 'yaml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ testpaths = [
   "everyvoice/tests/test_*.py",
   "everyvoice/model/*/*/*/tests/test_*.py",
 ]
+norecursedirs = [ "build", "dist", ".git", "regress*", "*venv*", ".mypy_cache" ]
 filterwarnings = [
   "ignore:Can't initialize NVML:UserWarning",
   "ignore:.*use of fork.. may lead to deadlocks in the child.:DeprecationWarning",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make the regression test suite work again.

As we changed the code, we let this get stale. We should be more diligent making sure CLI changes are reflected in the regression tests.

Note: the apparently unrelated `norecursedirs = [ "build", "dist", ".git", "regress-*", "*venv*", ".mypy_cache" ]` in `pyproject.toml` is essential here: when you run pytest after having created regression tests, the default discovery rules that pytest uses will search through the hundred thousand files that the regression suite creates, and we have to block that to keep things sane. The `testpaths` parameter also declared there only has an effect when you run from the EveryVoice sandbox root, but the `norecursedirs` setting is always taken into account, so excluding large directories using the latter is more important.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the regression suite and see that it works again

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high



<!-- Add any other relevant information here -->
