### PR TITLE
build(deps): force replace pydub by pydub_ng

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,13 @@ docs = [
   "mike>=1.1.2",
 ]
 
+[tool.uv]
+override-dependencies = [
+  # replace unmaintained pydub, which gradio requests, by pydub_ng
+  "pydub; python_version < '0'",
+  "pydub-ng>=0.2.0",
+]
+
 [project.scripts]
 everyvoice = "everyvoice.cli:app"
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+overrides = [
+    { name = "pydub", marker = "python_full_version < '0'" },
+    { name = "pydub-ng", specifier = ">=0.2.0" },
+]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -1093,7 +1099,6 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pydub" },
     { name = "python-multipart" },
     { name = "pytz" },
     { name = "pyyaml" },
@@ -2988,15 +2993,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/3f/9669fd933f5e344e811193438ba688f7abe0c64beddd8ee52fa53dad68d0/pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:578e24f761f3b425834f297b9935e1ce2e30f51400964ce4801002435a1b41ef", size = 2006230, upload-time = "2024-06-03T17:47:25.804Z" },
     { url = "https://files.pythonhosted.org/packages/b0/8a/c8a2e60482eebc5c878faf7067e63ef532d40b01870292a7da40506b2d5f/pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:81b5efb2f126454586d0f40c4d834010979cb80785173d1586df845a632e4e6d", size = 2109883, upload-time = "2024-06-03T17:47:28.84Z" },
     { url = "https://files.pythonhosted.org/packages/f5/6e/b753bb42bc8aff4fd34c6816f2a17e5e059217512e224a2aa31a1b2f8f93/pydantic_core-2.18.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ab86ce7c8f9bea87b9d12c7f0af71102acbf5ecbc66c17796cff45dae54ef9a5", size = 1917020, upload-time = "2024-06-03T17:47:31.227Z" },
-]
-
-[[package]]
-name = "pydub"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

`pydub` and `pydub-ng` cannot be installed at the same time: they provide the same files. `gradio` wants the former, `readalongs` wants the latter. Turns out `uv` has an override mechanism to handle that!

https://github.com/ReadAlongs/Studio/pull/289 for more details about pydub vs pydub-ng

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

gets rid of warnings from unmaintained pydub

### How to test? <!-- Explain how reviewers should test this PR. -->

See that CI's "test" job, "Run tests" step no longer has warnings `DeprecationWarning: invalid escape sequence '\('` about `pydub/utils.py`. (Although einops still has a similar warning--we'll have to bump that to a more recent version at some point.)

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no



<!-- Add any other relevant information here -->
