### PR TITLE
Fix test suites to accept help messages formatted by recent typer versions

### DIFF
--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -285,7 +285,7 @@ class TestCLI:
 
     def test_inspect_checkpoint_help(self):
         result = self.runner.invoke(app, ["checkpoint", "inspect", "--help"])
-        assert "checkpoint inspect [OPTIONS] MODEL_PATH" in result.stdout
+        assert "checkpoint inspect [OPTIONS]" in result.stdout
 
     def test_inspect_checkpoint(self):
         result = self.runner.invoke(
@@ -377,10 +377,7 @@ class TestCLI:
         # Exit code for no-arg-is-help is 0 with click<=8.1.8 and typer<=0.23.2,
         # 2 if either is more recent
         assert result.exit_code in (0, 2)
-        assert (
-            "preprocess text-to-wav [OPTIONS] CONFIG_FILE"
-            in flatten_log(result.output).strip()
-        )
+        assert "preprocess text-to-wav [OPTIONS]" in flatten_log(result.output)
 
     def test_expensive_imports_are_tucked_away(self):
         """Make sure expensive imports are tucked away form the CLI help"""

--- a/everyvoice/tests/test_demo.py
+++ b/everyvoice/tests/test_demo.py
@@ -34,7 +34,7 @@ class TestDemo:
         # 2 if either is more recent
         assert result.exit_code in (0, 2)
         # the runner calls "root" instead of "everyvoice"
-        assert "Usage: root demo [OPTIONS] CHECKPOINT" in flatten_log(result.output)
+        assert "Usage: root demo [OPTIONS]" in flatten_log(result.output)
 
         # Invalid --output-format value
         result = self.runner.invoke(


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

With typer 0.27.0, arguments that used to be shown as `MODEL_PATH` in the `-h` output are now shown as `{model_path}` instead. Let's just make our test assertions compatible with either by removing that part of the assertion text.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

error reported by Marc: when creating a fresh env using conda, `pytest` fails

### Feedback sought? <!-- What should reviewers focus on in particular? -->

validation that this fixes things for you too

### How to test? <!-- Explain how reviewers should test this PR. -->

`pytest` should now pass with a new env created using conda

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/FastSpeech2_lightning/pull/151

<!-- Add any other relevant information here -->
