### PR TITLE
Dev.ap/separate ckpts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,8 @@ jobs:
   # Automated due diligence: Make sure we don't introduce dependencies with incompatible licenses.
   # But: Ignore packages where auto analysis does not work but manual analysis says OK.
   # And: Ignore nvidia-*-cu12 packages used by the GPU back-end: OTHER/PROPRIETARY LICENSE
+  # And: Ignore fsspec which has a BSD-3 license but is not being picked up by licensecheck for some reason:
+  #      https://github.com/fsspec/filesystem_spec?tab=BSD-3-Clause-1-ov-file
   # And: llvmlite crashes licensecheck at the moment, but its license is OK so skip it.
   licensecheck:
     runs-on: ubuntu-latest
@@ -156,5 +158,5 @@ jobs:
       - name: Run license check overall
         run: |
           uvx licensecheck --requirements-paths pyproject.toml --zero \
-            --ignore-packages text-unidecode pympi-ling pyworld pyworld-prebuilt audioread anytree gradio hf-gradio setuptools 'nvidia-*' \
+            --ignore-packages text-unidecode pympi-ling pyworld fsspec pyworld-prebuilt audioread anytree gradio hf-gradio setuptools 'nvidia-*' \
           ! echo "Package(s) listed with an X above is/are potentially a problem. Please review their licenses for compatibility with EveryVoice."

--- a/docs/guides/styletts2.md
+++ b/docs/guides/styletts2.md
@@ -55,7 +55,7 @@ Which would use the GPU accelerator (`-a gpu`) and specify 4 devices/chips (`-d 
 StyleTTS2 generates speech by sampling a speaking style from a short reference audio clip. The reference audio should be a clean recording of a few seconds, but it doesn't need to match the text you want to synthesize. You can use any recording from your training data as a reference.
 
 ```bash
-everyvoice synthesize text-to-wav logs_and_checkpoints/E2E-Experiment/base/last.ckpt \
+everyvoice synthesize text-to-wav logs_and_checkpoints/E2E-Experiment/base/stage-2-last.ckpt \
     --reference path/to/reference.wav \
     --text "your text here"
 ```
@@ -63,7 +63,7 @@ everyvoice synthesize text-to-wav logs_and_checkpoints/E2E-Experiment/base/last.
 You can pass `--text` multiple times to synthesize several utterances at once:
 
 ```bash
-everyvoice synthesize text-to-wav logs_and_checkpoints/E2E-Experiment/base/last.ckpt \
+everyvoice synthesize text-to-wav logs_and_checkpoints/E2E-Experiment/base/stage-2-last.ckpt \
     --reference path/to/reference.wav \
     --text "First sentence." \
     --text "Second sentence."

--- a/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
+++ b/everyvoice/.schema/everyvoice-text-to-wav-0.5.json
@@ -1367,8 +1367,8 @@
           "type": "integer"
         },
         "first_stage_path": {
-          "default": "first_stage.pth",
-          "description": "Filename (relative to log_dir) where the stage 1 checkpoint is saved.",
+          "default": "stage-1-last.ckpt",
+          "description": "Filename (relative to log_dir) where the stage 1 checkpoint is saved. The default matches the checkpoint '--mode first' training produces automatically.",
           "title": "First Stage Path",
           "type": "string"
         },

--- a/everyvoice/tests/regression/regression-test.sh
+++ b/everyvoice/tests/regression/regression-test.sh
@@ -89,16 +89,13 @@ r "coverage run -p -m everyvoice preprocess text-to-wav config/everyvoice-text-t
 { echo ERROR: Preprocess for text-to-wav failed, aborting.; exit 1; }
 
 r "coverage run -p -m everyvoice train text-to-wav config/everyvoice-text-to-wav.yaml --mode first --config-args training.epochs_1st=$E2E_EPOCHS_1ST"
-E2E_STAGE1=logs_and_checkpoints/E2E-Experiment/base/last.ckpt
+E2E_STAGE1=logs_and_checkpoints/E2E-Experiment/base/stage-1-last.ckpt
 ls $E2E_STAGE1 || { echo ERROR: Training the StyleTTS2 stage-1 model failed, aborting.; exit 1; }
-# Stage 2 shares stage 1's log_dir and also writes a "last.ckpt", so copy stage
-# 1's checkpoint aside before it gets overwritten, and point stage 2 at it
-# explicitly -- training.first_stage_path isn't populated automatically.
-FIRST_STAGE_CKPT=logs_and_checkpoints/E2E-Experiment/base/first_stage.ckpt
-cp $E2E_STAGE1 $FIRST_STAGE_CKPT
 
-r "coverage run -p -m everyvoice train text-to-wav config/everyvoice-text-to-wav.yaml --mode second --config-args training.epochs_2nd=$E2E_EPOCHS_2ND --config-args training.first_stage_path=$FIRST_STAGE_CKPT"
-E2E=logs_and_checkpoints/E2E-Experiment/base/last.ckpt
+# Stage 2 automatically picks up stage 1's checkpoint via training.first_stage_path,
+# which defaults to stage-1-last.ckpt in the same log_dir.
+r "coverage run -p -m everyvoice train text-to-wav config/everyvoice-text-to-wav.yaml --mode second --config-args training.epochs_2nd=$E2E_EPOCHS_2ND"
+E2E=logs_and_checkpoints/E2E-Experiment/base/stage-2-last.ckpt
 ls $E2E || { echo ERROR: Training the StyleTTS2 text-to-wav model failed, aborting.; exit 1; }
 
 REF_WAV=$(find wavs -maxdepth 1 -name '*.wav' 2>/dev/null | sort | head -1)


### PR DESCRIPTION
Instead of --mode first and --mode second both producing `last.ckpt` checkpoints, they now produce `stage-1-last.ckpt` and `stage-2-last.ckpt`