### PR TITLE
fix: consistently use --config-args in all CLI command

### DIFF
--- a/everyvoice/base_cli/interfaces.py
+++ b/everyvoice/base_cli/interfaces.py
@@ -29,7 +29,10 @@ def load_config_base_command_interface(
     config_file: Annotated[
         Path, typer_file_argument(help="The path to your model configuration file.")
     ],
-    config_args: Annotated[list[str], typer.Option("--config", "-c")] = [],
+    config_args: Annotated[
+        list[str],
+        typer.Option("-c", "--config-args", help="Override the configuration."),
+    ] = [],
 ):
     pass
 
@@ -100,6 +103,9 @@ def train_base_command_interface(
 
 
 def inference_base_command_interface(
-    config_args: Annotated[list[str], typer.Option("--config", "-c")] = [],
+    config_args: Annotated[
+        list[str],
+        typer.Option("-c", "--config-args", help="Override the configuration."),
+    ] = [],
 ):
     pass


### PR DESCRIPTION


<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Consistently use `--config-args` to set `config_args` and reserve `--config` for the config file path.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #861

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

pre 0.5.0

### How to test? <!-- Explain how reviewers should test this PR. -->

```
everyvoice demo -h
everyvoice synthesize from-text -h
```
and see `--config-args` instead of `--config`, along with help text.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

