### PR TITLE
docs: add missing vocoder-path option to synthesize example

### DIFF
--- a/docs/guides/fastspeech2.md
+++ b/docs/guides/fastspeech2.md
@@ -63,7 +63,10 @@ When you have finished training your Feature Prediction Network, we recommend [f
 You can synthesize by pointing the CLI to your trained feature prediction network and passing in the text. You can export the wav or spectrogram (pt) files.
 
 ```bash
-everyvoice synthesize from-text logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt -t "මෙදා සැරේ සාකච්ඡාවක් විදියට නෙවෙයි නේද පල කරල තියෙන්නෙ" -a gpu -d 1 --output-type wav
+everyvoice synthesize from-text logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt \
+    --vocoder-path logs_and_checkpoints/VocoderExperiment/base/checkpoints/last.ckpt \
+    -t "මෙදා සැරේ සාකච්ඡාවක් විදියට නෙවෙයි නේද පල කරල තියෙන්නෙ" \
+    -a gpu -d 1 --output-type wav
 ```
 
 #### Demo App
@@ -71,7 +74,8 @@ everyvoice synthesize from-text logs_and_checkpoints/FeaturePredictionExperiment
 You can also synthesize audio by starting up the EveryVoice Demo using your Feature Prediction and Vocoder checkpoints:
 
 ```bash
-everyvoice demo logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt logs_and_checkpoints/VocoderExperiment/base/checkpoints/last.ckpt
+everyvoice demo logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt \
+    logs_and_checkpoints/VocoderExperiment/base/checkpoints/last.ckpt
 ```
 
 And an interactive demo will be available at [http://localhost:7260](http://localhost:7260)


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

I did a quick review of the current online documentation to make sure it was in sync with the software with all the changes we've been doing. You've already done a great job of it, all I found that had to be fixed in an error is fs2 synthesis that's clearly been there for a while: the `--vocoder-path` option is required to output wav.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Slightly wrong documentation.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

regular review

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before 0.5.0

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

