### PR TITLE
Refactor StyleTTS2Module to StyleTTS2

### DIFF
--- a/everyvoice/base_cli/checkpoint.py
+++ b/everyvoice/base_cli/checkpoint.py
@@ -107,10 +107,10 @@ def summarize_styletts2_model(model_path: Path, checkpoint: dict) -> None:
     from torchinfo import summary
 
     from everyvoice.model.e2e.StyleTTS2_lightning.styletts2.lightning import (
-        StyleTTS2Module,
+        StyleTTS2,
     )
 
-    model = StyleTTS2Module.load_from_checkpoint(model_path)
+    model = StyleTTS2.load_from_checkpoint(model_path)
     print(summary(model, None, verbose=0))
 
 
@@ -220,6 +220,8 @@ def inspect(
                 "FastSpeech2": summarize_fs2_model,
                 "HiFiGAN": summarize_hfgl_model,
                 "HiFiGANGenerator": summarize_hfgl_generator_model,
+                "StyleTTS2": summarize_styletts2_model,
+                # Pre-rename name still present in older checkpoints.
                 "StyleTTS2Module": summarize_styletts2_model,
             }
             summarizer = model_summarizers.get(checkpoint["model_info"]["name"], None)

--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -19,8 +19,8 @@ from everyvoice.config.type_definitions import TargetTrainingTextRepresentationL
 from everyvoice.exceptions import InvalidConfiguration
 from everyvoice.model.e2e.config import StyleTTS2Config
 from everyvoice.model.e2e.StyleTTS2_lightning.styletts2.lightning import (
+    StyleTTS2,
     StyleTTS2DataModule,
-    StyleTTS2Module,
 )
 from everyvoice.model.feature_prediction.config import FastSpeech2Config
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.dataset import (
@@ -181,7 +181,7 @@ def train_base_command(
         type[FastSpeech2DataModule],
         type[HiFiGANDataModule],
     ],
-    model: Union[type[StyleTTS2Module], type[FastSpeech2], type[HiFiGAN]],
+    model: Union[type[StyleTTS2], type[FastSpeech2], type[HiFiGAN]],
     monitor: str,
     # Must include the above in model-specific command
     config_args: list[str],
@@ -291,9 +291,7 @@ def train_base_command(
             sys.exit(1)
         logger.info(f"Model's architecture\n{model_obj}")
         # Check if the trainer has changed (but ignore subdir since it is specific to the run)
-        if isinstance(model_obj, StyleTTS2Module) or isinstance(
-            config, StyleTTS2Config
-        ):
+        if isinstance(model_obj, StyleTTS2) or isinstance(config, StyleTTS2Config):
             optimizer_diff = DeepDiff((), ())
             model_diff = DeepDiff((), ())
         else:

--- a/everyvoice/cli.py
+++ b/everyvoice/cli.py
@@ -675,7 +675,8 @@ AllowedDemoOutputFormats = Enum(  # type: ignore
 
 _VOCODER_CLASS_NAMES = {"HiFiGAN", "HiFiGANGenerator"}
 _FS2_CLASS_NAMES = {"FastSpeech2"}
-_STYLETTS2_CLASS_NAMES = {"StyleTTS2Module"}
+# "StyleTTS2Module" is the pre-rename name still present in older checkpoints.
+_STYLETTS2_CLASS_NAMES = {"StyleTTS2", "StyleTTS2Module"}
 
 
 def _peek_model_class(checkpoint_path: Path) -> str:
@@ -713,7 +714,7 @@ def peek_text_representation(checkpoint_path: Path) -> str:
     if not isinstance(config, dict):
         return ""
     # FastSpeech2 stores its config directly under "model"; StyleTTS2 wraps it
-    # under an "ev_config" key (see StyleTTS2Module.on_save_checkpoint).
+    # under an "ev_config" key (see StyleTTS2.on_save_checkpoint).
     model_config = config.get("ev_config", config)
     if not isinstance(model_config, dict):
         return ""

--- a/everyvoice/demo/app.py
+++ b/everyvoice/demo/app.py
@@ -524,7 +524,7 @@ def synthesize_audio_styletts2(
         DatasetTextRepresentation | str
     ) = DatasetTextRepresentation.characters,  # from a live Radio, or a fixed gr.State when the selector is hidden
     *,
-    module,
+    model,
     mel_transform,
     device,
     output_dir: Path,
@@ -565,7 +565,7 @@ def synthesize_audio_styletts2(
 
         try:
             ref_s = load_reference_style(
-                module, mel_transform, Path(user_reference), device
+                model, mel_transform, Path(user_reference), device
             )
         except Exception as e:
             raise gr.Error(f"Could not load reference audio: {e}")
@@ -587,20 +587,20 @@ def synthesize_audio_styletts2(
     from everyvoice.text.textsplit import chunk_text
 
     split_text, split_params = get_styletts2_text_split_params(
-        module, language, text_representation
+        model, language, text_representation
     )
     chunks = chunk_text(text, *split_params) if split_text else [text]
 
     lang_emb = None
-    if language is not None and hasattr(module, "language_embedding"):
-        lang_id = torch.LongTensor([module.lang2id[language]]).to(device)
-        lang_emb = module.language_embedding(lang_id)
+    if language is not None and hasattr(model, "language_embedding"):
+        lang_id = torch.LongTensor([model.lang2id[language]]).to(device)
+        lang_emb = model.language_embedding(lang_id)
 
     chunk_wavs = []
     for chunk in chunks:
         try:
             tokens = encode_text_for_inference(
-                module, chunk, language, text_representation
+                model, chunk, language, text_representation
             ).to(device)
         except (ValueError, NotImplementedError) as e:
             raise gr.Error(str(e))
@@ -608,7 +608,7 @@ def synthesize_audio_styletts2(
 
         try:
             chunk_wavs.append(
-                module._synthesize_text(
+                model._synthesize_text(
                     tokens,
                     input_lengths,
                     ref_s=ref_s,
@@ -631,7 +631,7 @@ def synthesize_audio_styletts2(
     import soundfile as sf
 
     out_path = output_dir / (slugify(text[:50]) + ".wav")
-    sf.write(str(out_path), audio, module.sr)
+    sf.write(str(out_path), audio, model.sr)
     return str(out_path)
 
 
@@ -807,7 +807,7 @@ def create_demo_app_styletts2(
 
     synthesize_fn = partial(
         synthesize_audio_styletts2,
-        module=model,
+        model=model,
         mel_transform=mel_transform,
         device=device,
         output_dir=output_dir,

--- a/everyvoice/tests/test_demo.py
+++ b/everyvoice/tests/test_demo.py
@@ -454,6 +454,9 @@ class TestDemo:
             fake_ckpt = tmpdir / "styletts2.ckpt"
             torch.save(
                 {
+                    # "StyleTTS2Module" is the pre-rename class name; older
+                    # checkpoints carry it and must still dispatch to the
+                    # StyleTTS2 demo path.
                     "model_info": {"name": "StyleTTS2Module"},
                     "hyper_parameters": {"mode": "second", "config": {}},
                     "state_dict": {},
@@ -655,13 +658,13 @@ class TestStyleTTS2DemoChunking:
     concatenating the per-chunk waveforms into a single output file."""
 
     @staticmethod
-    def _fake_module(split_text: bool):
+    def _fake_model(split_text: bool):
         import types
 
         import numpy as np
 
-        module = types.SimpleNamespace()
-        module.config = {
+        model = types.SimpleNamespace()
+        model.config = {
             "ev_config": types.SimpleNamespace(
                 text=types.SimpleNamespace(
                     split_text=split_text,
@@ -669,20 +672,20 @@ class TestStyleTTS2DemoChunking:
                 )
             )
         }
-        module.sr = 16000
-        module.calls = []  # one entry per _synthesize_text call
+        model.sr = 16000
+        model.calls = []  # one entry per _synthesize_text call
 
         def _synthesize_text(_tokens, _input_lengths, **kwargs):
-            module.calls.append(kwargs)
+            model.calls.append(kwargs)
             return np.zeros(100, dtype=np.float32)
 
-        module._synthesize_text = _synthesize_text
+        model._synthesize_text = _synthesize_text
         # No language_embedding attribute -> lang_emb stays None
-        return module
+        return model
 
     _LONG_TEXT = " ".join(f"This is sentence number {i}." for i in range(20))
 
-    def _synth(self, tmp_path, module):
+    def _synth(self, tmp_path, model):
         import torch
 
         from everyvoice.demo.app import synthesize_audio_styletts2
@@ -700,7 +703,7 @@ class TestStyleTTS2DemoChunking:
                 0.3,
                 0.7,
                 "eng",
-                module=module,
+                model=model,
                 mel_transform=None,
                 device="cpu",
                 output_dir=tmp_path,
@@ -718,14 +721,14 @@ class TestStyleTTS2DemoChunking:
         expected_chunks = chunk_text(self._LONG_TEXT, 100, 200, "!?.", ":;,")
         assert len(expected_chunks) > 1  # sanity: input is long enough to split
 
-        module = self._fake_module(split_text=True)
-        out_path = self._synth(tmp_path, module)
+        model = self._fake_model(split_text=True)
+        out_path = self._synth(tmp_path, model)
 
-        assert len(module.calls) == len(expected_chunks)
+        assert len(model.calls) == len(expected_chunks)
         audio, _ = sf.read(out_path)
         assert len(audio) == 100 * len(expected_chunks)
 
     def test_no_chunking_when_split_text_disabled(self, tmp_path):
-        module = self._fake_module(split_text=False)
-        self._synth(tmp_path, module)
-        assert len(module.calls) == 1
+        model = self._fake_model(split_text=False)
+        self._synth(tmp_path, model)
+        assert len(model.calls) == 1


### PR DESCRIPTION
This is a refactor for the PyTorch Lightning based Module suffixed StyleTTS2Module class (and other related `module` named variables) to StyleTTS2 (and `model` named variables) which is more in-line with other EveryVoice models. It also retains backward compat with StyleTTS2Module trained checkpoints.

Assisted by Claude Sonnet 5

Related:

https://github.com/EveryVoiceTTS/StyleTTS2/pull/28