### PR TITLE
docs: remove the under construction banner for the docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,6 +1,0 @@
-{% extends "base.html" %} {% block announce %}
-<div style="text-align: center;">
-    <p style="color:white; display:inline;">🚧 Under Construction! EveryVoice is pre-beta and should not be expected to work fully. Please check back later for a stable release. 🚧</p>
-</div>
-<!-- Add announcement here, including arbitrary HTML -->
-{% endblock %}


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Remove the under construction banner from our documentation.

I have two options:
 - replace the banner text by some new announcement
 - remove the override that allows a banner text

I chose the latter because I don't think we have an announcement to place there now.

If we want to add an announcement again in the future, we can restore `docs/overrides/main.html` then.

### Post PR task

If this is OK, I will then also run 

    uv run mike deploy --update-aliases v0.5.0 stable latest

locally and push the results to retroactively remove the banner on v0.5.0