### PR TITLE
save and reload checkpoints on SIGTERM

### DIFF
--- a/everyvoice/base_cli/helpers.py
+++ b/everyvoice/base_cli/helpers.py
@@ -213,6 +213,7 @@ def train_base_command(
     pbar.update()
     pbar.refresh()
     from pytorch_lightning.loggers import TensorBoardLogger
+    from pytorch_lightning.plugins.environments import SLURMEnvironment
 
     pbar.update()
     pbar.refresh()
@@ -234,6 +235,7 @@ def train_base_command(
     last_ckpt_callback = ModelCheckpoint(
         save_top_k=1,
         save_last=True,
+        save_on_exception=True,
         every_n_train_steps=config.training.ckpt_steps,
         every_n_epochs=config.training.ckpt_epochs,
         enable_version_counter=True,
@@ -269,6 +271,17 @@ def train_base_command(
         gradient_clip_val=gradient_clip_val,
     )
     data = data_module(config)
+
+    # A checkpoint saved just before a SLURM requeue/preemption (via SIGUSR1)
+    # takes priority over finetune_checkpoint, so a requeued job resumes the
+    # progress made this run instead of restarting from the finetune source.
+    if SLURMEnvironment.detect():
+        try:
+            trainer.fit(model(config, **model_kwargs), data, ckpt_path="hpc")
+            return
+        except ValueError:
+            pass  # no HPC checkpoint yet; continue with normal startup below
+
     last_ckpt = (
         config.training.finetune_checkpoint
         if config.training.finetune_checkpoint is not None

--- a/everyvoice/tests/regression/README.md
+++ b/everyvoice/tests/regression/README.md
@@ -48,3 +48,24 @@ All the above can be accomplished by running `go.sh`.
 For NRC clusters, use `sbatch go-<clustername>.sh` to get the appropriate Slurm
 parameters. To run this on a different cluster, copy one of the go-*.sh scripts
 and customize it with the right partition and account for you.
+
+## Surviving requeue and preemption
+
+`everyvoice train` relies on PyTorch Lightning's built-in Slurm support to save
+a checkpoint and requeue itself before the job is killed, whether that's from
+hitting the time limit, preemption, or `scancel`. To enable it, add to your
+`sbatch` script (or `go-<clustername>.sh`):
+
+```sh
+#SBATCH --requeue
+#SBATCH --signal=B:USR1@300
+```
+
+`B:` sends the signal to the batch shell so it reaches the training process,
+and `@300` asks Slurm to send `SIGUSR1` 300 seconds before it sends `SIGTERM`
+(and, if `--requeue` is set, calls `scontrol requeue` for you). Make sure the
+grace period is long enough for a full checkpoint (model + optimizer state) to
+write on your cluster's filesystem — start conservative and tune down once
+you've observed the actual write time for your model. Resubmitting from the
+same working directory (which `scontrol requeue` does automatically) picks the
+checkpoint back up with no extra flags needed.

--- a/everyvoice/tests/test_cli.py
+++ b/everyvoice/tests/test_cli.py
@@ -20,7 +20,10 @@ from yaml import CLoader as Loader
 
 from everyvoice import __file__ as EV_FILE
 from everyvoice._version import VERSION
-from everyvoice.base_cli.helpers import save_configuration_to_log_dir
+from everyvoice.base_cli.helpers import (
+    save_configuration_to_log_dir,
+    train_base_command,
+)
 from everyvoice.cli import SCHEMAS_TO_OUTPUT, app
 from everyvoice.config.shared_types import ContactInformation
 from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.config import (
@@ -731,6 +734,116 @@ class TestCLI:
         assert "has no pretrained text-encoder symbol table" in flatten_log(
             result.output
         )
+
+
+class TestTrainBaseCommandSlurmResume:
+    """everyvoice/base_cli/helpers.py train_base_command: saving/resuming
+    around a SLURM requeue or preemption (SIGUSR1/SIGTERM)."""
+
+    def _config(self, tmp_path, finetune_checkpoint=None):
+        return FastSpeech2Config(
+            contact=ContactInformation(
+                contact_name="Test Runner", contact_email="info@everyvoice.ca"
+            ),
+            training={
+                "logger": {"save_dir": tmp_path / "log", "name": "unittest"},
+                "finetune_checkpoint": finetune_checkpoint,
+            },
+        )
+
+    def _run_train_base_command(self, config):
+        train_base_command(
+            model_config=FastSpeech2Config,
+            data_module=mock.Mock(),
+            model=mock.Mock(),
+            monitor="validation/total_loss",
+            config_args=[],
+            config_file=Path("unused.yaml"),
+            accelerator="cpu",
+            devices="1",
+            nodes=1,
+            strategy="auto",
+            gradient_clip_val=None,
+        )
+
+    def test_last_ckpt_callback_saves_on_exception(self, tmp_path):
+        """A SIGTERM should force a checkpoint save regardless of
+        every_n_train_steps/every_n_epochs boundaries."""
+        config = self._config(tmp_path)
+        with (
+            mock.patch(
+                "everyvoice.base_cli.helpers.load_config_base_command",
+                return_value=config,
+            ),
+            mock.patch("everyvoice.base_cli.helpers.save_configuration_to_log_dir"),
+            mock.patch(
+                "pytorch_lightning.plugins.environments.SLURMEnvironment.detect",
+                return_value=False,
+            ),
+            mock.patch("pytorch_lightning.loggers.TensorBoardLogger"),
+            mock.patch("pytorch_lightning.Trainer"),
+            mock.patch(
+                "pytorch_lightning.callbacks.ModelCheckpoint"
+            ) as MockModelCheckpoint,
+        ):
+            self._run_train_base_command(config)
+
+        # last_ckpt_callback is the first ModelCheckpoint(...) constructed
+        last_ckpt_kwargs = MockModelCheckpoint.call_args_list[0].kwargs
+        assert last_ckpt_kwargs["save_on_exception"] is True
+
+    def test_resumes_from_slurm_hpc_checkpoint_when_present(self, tmp_path):
+        """When Slurm is detected and an HPC checkpoint (saved by Lightning
+        just before a requeue/preemption) exists, it must take priority over
+        finetune_checkpoint."""
+        config = self._config(
+            tmp_path, finetune_checkpoint=str(tmp_path / "finetune.ckpt")
+        )
+        with (
+            mock.patch(
+                "everyvoice.base_cli.helpers.load_config_base_command",
+                return_value=config,
+            ),
+            mock.patch("everyvoice.base_cli.helpers.save_configuration_to_log_dir"),
+            mock.patch(
+                "pytorch_lightning.plugins.environments.SLURMEnvironment.detect",
+                return_value=True,
+            ),
+            mock.patch("pytorch_lightning.loggers.TensorBoardLogger"),
+            mock.patch("pytorch_lightning.Trainer") as MockTrainer,
+            mock.patch("pytorch_lightning.callbacks.ModelCheckpoint"),
+        ):
+            self._run_train_base_command(config)
+            fit = MockTrainer.return_value.fit
+            fit.assert_called_once()
+            assert fit.call_args.kwargs["ckpt_path"] == "hpc"
+
+    def test_falls_back_when_no_slurm_hpc_checkpoint(self, tmp_path):
+        """When Slurm is detected but no HPC checkpoint exists yet, training
+        should fall through to the normal startup logic instead of failing."""
+        config = self._config(tmp_path)
+        with (
+            mock.patch(
+                "everyvoice.base_cli.helpers.load_config_base_command",
+                return_value=config,
+            ),
+            mock.patch("everyvoice.base_cli.helpers.save_configuration_to_log_dir"),
+            mock.patch(
+                "pytorch_lightning.plugins.environments.SLURMEnvironment.detect",
+                return_value=True,
+            ),
+            mock.patch("pytorch_lightning.loggers.TensorBoardLogger"),
+            mock.patch("pytorch_lightning.Trainer") as MockTrainer,
+            mock.patch("pytorch_lightning.callbacks.ModelCheckpoint"),
+        ):
+            MockTrainer.return_value.fit.side_effect = [
+                ValueError("no HPC checkpoint"),
+                None,
+            ]
+            self._run_train_base_command(config)
+            fit = MockTrainer.return_value.fit
+            assert fit.call_count == 2
+            assert fit.call_args_list[0].kwargs["ckpt_path"] == "hpc"
 
 
 class TestBaseCLIHelper:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "ilt-panphon>=0.20.1,<0.21",
   "ipatok>=0.4.1",
   "librosa==0.11.0",
-  "lightning>=2.1.0",
+  "lightning>=2.5.3",
   "loguru>=0.6.0",
   "matplotlib>=3.9.0",
   "merge-args",

--- a/uv.lock
+++ b/uv.lock
@@ -970,7 +970,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.17.3" },
     { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4.17.3" },
     { name = "librosa", specifier = "==0.11.0" },
-    { name = "lightning", specifier = ">=2.1.0" },
+    { name = "lightning", specifier = ">=2.5.3" },
     { name = "loguru", specifier = ">=0.6.0" },
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "merge-args" },


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

We're getting a lot of pre-empted jobs on HPC and I'd like to save a checkpoint on the SIGTERM signal and re-load from that (instead of any possibly-defined finetune-ckpt). This PR attempts to use PyTorch Lightning's internal save-on-exception handling to do that.

Supported by Claude Code Sonnet 5

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Code review, I want to test this with some dummy jobs on multiple clusters before merging.


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

some mocked tests

### How to test? <!-- Explain how reviewers should test this PR. -->

run the tests, but I also want to create a dummy job with an artificially low amount of allocated time.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

low-medium, I need to try this on different clusters

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



### Related PRs? <!-- List any submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/StyleTTS2/pull/30

<!-- Add any other relevant information here -->
